### PR TITLE
Unify `__repr__` format across classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Traktor playlist `NMLPlaylistCollection` is now aligned with the `PlaylistCollection` protocol
 - Enhanced typing for `Matches` class and collection protocols by using a TypeVar for Tracks.
 - Nbstripout keeps outputs now
+- Unified `__repr__` format to ClassName(key=value)
 
 ## [0.3.0] - 2026-02-16
 
@@ -79,7 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tooling: Ruff target-version bumped from Python 3.10 to 3.11.
 - Test suite reorganization:
   - Beets and Traktor tests moved under `tests/services/...`; Traktor tests now skip cleanly when optional dependencies are missing.
-
 - Enhanced README, added LICENCE, reformatted CHANGELOG.
 
 ## [0.2.0] - 2025-10-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## Upcoming
 
 ### Added
 
 - Traktor config option `backup_before_write`, (true by default, creates a backup of the nml file before each write).
+
+### Changed
+
+- Unified `__repr__` format to ClassName(key=value)
 
 ## [0.4.0] - 2026-03-07
 
@@ -34,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Traktor playlist `NMLPlaylistCollection` is now aligned with the `PlaylistCollection` protocol
 - Enhanced typing for `Matches` class and collection protocols by using a TypeVar for Tracks.
 - Nbstripout keeps outputs now
-- Unified `__repr__` format to ClassName(key=value)
 
 ## [0.3.0] - 2026-02-16
 

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -404,3 +404,6 @@ class LibraryCollection(Generic[T, C], Collection[T]):
         Return ``None`` for name searches that fail.
         """
         ...
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}()"

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -105,9 +105,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         self.info = info
 
     def __repr__(self) -> str:
-        return (
-            f'{type(self).__name__} {hex(id(self))} ["{self.name}", {len(self)} tracks]'
-        )
+        return f"{type(self).__name__}(name={self.name!r}, tracks={len(self)})"
 
     # -------------------------------- Tracks -------------------------------- #
 

--- a/plistsync/core/rewrite.py
+++ b/plistsync/core/rewrite.py
@@ -56,3 +56,6 @@ class PathRewrite(NamedTuple):
     def invert(self) -> PathRewrite:
         """Invert the rewrite rule."""
         return PathRewrite(self.new, self.old)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(old='{str(self.old)}', new='{str(self.new)}')"

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -220,4 +220,7 @@ class Track(ABC):
         return hash((info_hash, global_ids_hash, local_ids_hash))
 
     def __repr__(self) -> str:
-        return f"Track[{self.primary_artist} > {self.title}, hash: {hash(self)}]"
+        cls = type(self).__name__
+        artist = self.primary_artist or "?"
+        title = self.title or "?"
+        return f"{cls}(artist={artist!r}, title={title!r})"

--- a/plistsync/services/traktor/path.py
+++ b/plistsync/services/traktor/path.py
@@ -122,4 +122,4 @@ class NMLPath:
         return "/:".join(self._parts)
 
     def __repr__(self) -> str:
-        return f"TraktorPath[{str(self)}, {hash(self)}]"
+        return f"{type(self).__name__}(path={str(self)!r})"

--- a/plistsync/services/traktor/track.py
+++ b/plistsync/services/traktor/track.py
@@ -223,9 +223,6 @@ class NMLPlaylistTrack(Track):
         """The path to the track file on disk."""
         return self.traktor_path.pure_path
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}[{self.path}]"
-
     # ------------------------------- Contracts ------------------------------ #
 
     @property

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -123,6 +123,22 @@ class TestPlaylistCollection:
 
         assert pl.name == "foo"  # rollback
 
+    @pytest.mark.parametrize(
+        ["name", "n_tracks", "expected_repr"],
+        [
+            ("Name", 0, "Playlist(name='Name', tracks=0)"),
+            ("Name", 10, "Playlist(name='Name', tracks=10)"),
+        ],
+    )
+    def test_repr(self, make_playlist, name, n_tracks, expected_repr):
+        repr_str = repr(
+            make_playlist(
+                name=name,
+                ids=[i for i in range(n_tracks)],
+            )
+        )
+        assert expected_repr in repr_str
+
 
 class TestPlaylistRemoteLifecycle:
     def test_create(self, make_playlist) -> None:

--- a/tests/core/test_rewrite.py
+++ b/tests/core/test_rewrite.py
@@ -53,3 +53,8 @@ class TestPathRewrite:
         rewrite = PathRewrite.from_str("/old", "/new")
         with pytest.raises(AttributeError):
             rewrite.old = Path("/changed")  # type: ignore
+
+    def test_repr(self):
+        rewrite = PathRewrite.from_str("/source", "/dest")
+        repr_str = repr(rewrite)
+        assert repr_str == "PathRewrite(old='/source', new='/dest')"

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -161,26 +161,20 @@ class TestTrack:
         assert "local_ids.beets_id" in diffs
         assert diffs["local_ids.beets_id"] == (None, 42)
 
-    def test_track_repr(self):
+    @pytest.mark.parametrize(
+        ["title", "artists", "expected_repr"],
+        [
+            ("Song", ["Artist"], "Track(artist='Artist', title='Song')"),
+            ("Song", [], "Track(artist='?', title='Song')"),
+            ("", ["Artist"], "Track(artist='Artist', title='?')"),
+            ("", [], "Track(artist='?', title='?')"),
+            (None, [], "Track(artist='?', title='?')"),
+        ],
+    )
+    def test_repr(self, title, artists, expected_repr):
         """Test the string representation of a track."""
-        track = MockTrack(title="Test Song", artists=["Test Artist"])
-        repr_str = repr(track)
-
-        assert "Track[" in repr_str
-        assert "Test Artist" in repr_str
-        assert "Test Song" in repr_str
-        # Should include the hash
-        assert str(hash(track)) in repr_str
-
-    def test_track_repr_no_artist(self):
-        """Test repr when track has no artist."""
-        track = MockTrack(title="Song Without Artist", artists=[])
-        repr_str = repr(track)
-
-        assert "Track[" in repr_str
-        assert "Song Without Artist" in repr_str
-        # Should handle None primary_artist gracefully
-        assert "None" in repr_str or " > " in repr_str
+        repr_str = repr(MockTrack(title=title, artists=artists))
+        assert expected_repr in repr_str
 
     def test_mock_track_serialize_deserialize(self):
         """Test MockTrack serialization and deserialization."""

--- a/uv.lock
+++ b/uv.lock
@@ -1723,7 +1723,7 @@ wheels = [
 
 [[package]]
 name = "plistsync"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "eyconf", extra = ["cli"] },


### PR DESCRIPTION
Currently the `__repr__` implementations across the codebase are inconsistent, using a mix of square brackets (`[]`) and round parentheses (`()`), and differing formats for displaying object state.

This PR standardizes the `__repr__` format to a consistent, Python-style representation:

```python
Class(key=value, ...)
```

Unknown or missing values are represented as `?` for readability.

Examples:

```python
MockTrack(artist='?', title='Song Without Artist')
MockPlaylist(name='Foo', tracks=10)
NMLPath(path="/:clean/:3 Doors Down/:3 Doors Down/:03 It's Not My Time [278kbps].mp3")
```

closes #37 