### PR TITLE
Support batched operations for track inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Traktor config option `backup_before_write`, (true by default, creates a backup of the nml file before each write).
 - `pyproject.toml` information updated (readme, license, authors, urls, classifiers).
+- Added support for batched remote operations, should allow to minify expensive network request.
 
 ### Changed
 

--- a/plistsync/core/diff.py
+++ b/plistsync/core/diff.py
@@ -118,7 +118,19 @@ class Operations(Generic[T]):
 def batch_consecutive(
     ops: Iterable[Step[T]],
 ) -> Iterator[list[Step[T]]]:
-    """Yield batches of consecutive operations of the same type."""
+    """
+    Yield batches of consecutive operations of the same type.
+
+    - Consecutive inserts -> single batch
+    - Non-consecutive inserts -> separate batches
+    - Consecutive deletes -> single batch
+    - Different types -> separate batches
+    - Moves -> each in own batch
+
+    Note:
+    This is optimized for common api support, e.g. spotify and tidal only support
+    batch operations for consecutive indices
+    """
     ops = list(ops)
     if not ops:
         return

--- a/plistsync/core/diff.py
+++ b/plistsync/core/diff.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import bisect
+from abc import ABC
 from collections import Counter, defaultdict
-from collections.abc import Callable, Hashable, Iterator, Sequence
+from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import Generic, TypeAlias, TypeVar
 
@@ -10,7 +11,15 @@ T = TypeVar("T")
 
 
 @dataclass(slots=True, frozen=True)
-class MoveOp(Generic[T]):
+class BaseOp(Generic[T], ABC):
+    """Base class for all diff operations."""
+
+    item: T
+    """The item involved in the operation."""
+
+
+@dataclass(slots=True, frozen=True)
+class MoveOp(BaseOp[T]):
     """Represents a move operation in a list diff."""
 
     old_idx: int
@@ -19,87 +28,126 @@ class MoveOp(Generic[T]):
     new_idx: int
     """The target index in the live list after the move."""
 
-    item: T
-    """The item to move."""
-
 
 @dataclass(slots=True, frozen=True)
-class InsertOp(Generic[T]):
+class InsertOp(BaseOp[T]):
     """Represents an insertion operation in a list diff."""
 
     idx: int
     """Live index at which the item should be inserted."""
 
-    item: T
-    """The item to insert into the list."""
-
 
 @dataclass(slots=True, frozen=True)
-class DeleteOp(Generic[T]):
+class DeleteOp(BaseOp[T]):
     """Represents a deletion operation in a list diff."""
 
     idx: int
     """Live index of the item to delete."""
 
-    item: T
-    """The item to remove from the list."""
+
+Op: TypeAlias = BaseOp[T]
 
 
-Ops: TypeAlias = InsertOp[T] | DeleteOp[T] | MoveOp[T]
+@dataclass(slots=True, frozen=True)
+class Step(Generic[T]):
+    """Represents a single operation applied to a list."""
+
+    op: Op[T]
+    """The single operation to apply."""
+
+    list_before: list[T]
+    """The list state before this operation was applied."""
+
+
+Ops: TypeAlias = MoveOp[T] | InsertOp[T] | DeleteOp[T]
 
 
 @dataclass
 class Operations(Generic[T]):
     """Container for a sequence of list diff operations."""
 
-    ops: list[InsertOp[T] | DeleteOp[T] | MoveOp[T]]
+    ops: list[Ops[T]]
     """List of operations to transform old_list into the target list."""
     old_list: list[T]
     """The original list before applying operations."""
 
-    def __iter__(self) -> Iterator[InsertOp[T] | DeleteOp[T] | MoveOp[T]]:
-        """Iterate operations with live list snapshots after each step."""
-        self._live_list = self.old_list[:]
-
+    def iter(self) -> Iterator[Step[T]]:
+        """Iterate operations as Step objects."""
+        # Yield each operation individually
+        working_list = self.old_list.copy()
         for op in self.ops:
-            if isinstance(op, MoveOp):
-                # Find the exact object to move
-                try:
-                    current_idx = next(
-                        i for i, v in enumerate(self._live_list) if v is op.item
-                    )
-                except StopIteration:
-                    continue  # already deleted
-                if current_idx == op.new_idx:
-                    continue  # already at target
-                val = self._live_list.pop(current_idx)
-                self._live_list.insert(op.new_idx, val)
-                yield op
+            list_before = working_list.copy()
+            if self._apply_op_to_list(op, working_list):
+                yield Step(op=op, list_before=list_before)
 
-            elif isinstance(op, InsertOp):
-                if op.idx < len(self._live_list) and self._live_list[op.idx] is op.item:
-                    continue  # already inserted
-                self._live_list.insert(op.idx, op.item)
-                yield op
+    def _apply_op_to_list(self, op: Ops[T], working_list: list[T]) -> bool:
+        """Apply operation to target list, returns whether operation was applied."""
+        if isinstance(op, MoveOp):
+            try:
+                current_idx = next(
+                    i for i, v in enumerate(working_list) if v is op.item
+                )
+            except StopIteration:
+                return False  # already deleted
+            if current_idx == op.new_idx:
+                return False  # already at target
 
-            elif isinstance(op, DeleteOp):
-                # Find the item by identity
-                try:
-                    current_idx = next(
-                        i for i, v in enumerate(self._live_list[:]) if v is op.item
-                    )
-                except StopIteration:
-                    continue  # already deleted
-                self._live_list.pop(current_idx)
-                yield op
+            val = working_list.pop(current_idx)
+            working_list.insert(op.new_idx, val)
 
-    def __getitem__(self, index: int) -> InsertOp[T] | DeleteOp[T] | MoveOp[T]:
+        elif isinstance(op, InsertOp):
+            if op.idx < len(working_list) and working_list[op.idx] is op.item:
+                return False  # already inserted
+            working_list.insert(op.idx, op.item)
+
+        elif isinstance(op, DeleteOp):
+            try:
+                current_idx = next(
+                    i for i, v in enumerate(working_list) if v is op.item
+                )
+            except StopIteration:
+                return False  # already deleted
+            working_list.pop(current_idx)
+
+        return True
+
+    def __getitem__(self, index: int) -> Op[T]:
         return self.ops[index]
 
-    @property
-    def live_list(self) -> list[T]:
-        """Current state of the list after all applied operations."""
-        return getattr(self, "_live_list", self.old_list[:])
+
+def batch_consecutive(
+    ops: Iterable[Step[T]],
+) -> Iterator[list[Step[T]]]:
+    """Yield batches of consecutive operations of the same type."""
+    ops = list(ops)
+    if not ops:
+        return
+    batch = [ops[0]]
+    for step in ops[1:]:
+        prev_op = batch[-1].op
+        curr_op = step.op
+
+        # Different type -> new batch
+        if type(prev_op) is not type(curr_op):
+            yield batch
+            batch = [step]
+            continue
+
+        # Check consecutiveness
+        is_consecutive = False
+        if isinstance(prev_op, InsertOp) and isinstance(curr_op, InsertOp):
+            is_consecutive = curr_op.idx == prev_op.idx + 1
+        elif isinstance(prev_op, DeleteOp) and isinstance(curr_op, DeleteOp):
+            is_consecutive = curr_op.idx == prev_op.idx - 1
+
+        if is_consecutive:
+            batch.append(step)
+        else:
+            yield batch
+            batch = [step]
+
+    if batch:
+        yield batch
 
 
 def list_diff(
@@ -154,7 +202,7 @@ def list_diff(
     # Create DeleteOps in reverse order (largest idx first)
     ops: list[InsertOp[T] | DeleteOp[T] | MoveOp[T]] = []
     for idx in reversed(indices_to_delete):
-        ops.append(DeleteOp(idx, old[idx]))
+        ops.append(DeleteOp(item=old[idx], idx=idx))
 
     # Step 2: Match, insert missing items, and move to correct positions
     # Build mapping from hash to list of indices in live_list
@@ -186,7 +234,11 @@ def list_diff(
             # matched an existing item
             if matched_old_idx != target_idx:
                 ops.append(
-                    MoveOp(matched_old_idx, target_idx, live_list[matched_old_idx])
+                    MoveOp(
+                        old_idx=matched_old_idx,
+                        new_idx=target_idx,
+                        item=live_list[matched_old_idx],
+                    )
                 )
                 val = live_list.pop(matched_old_idx)
                 live_list.insert(target_idx, val)
@@ -201,11 +253,10 @@ def list_diff(
                     shift_indices(lst, target_idx, +1)
         else:
             # no matching old item -> insert
-            ops.append(InsertOp(target_idx, target_item))
+            ops.append(InsertOp(idx=target_idx, item=target_item))
             live_list.insert(target_idx, target_item)
             # shift unmatched indices >= target_idx
             shift_indices(unmatched_old_indices, target_idx, +1)
             for lst in hash_to_indices.values():
                 shift_indices(lst, target_idx, +1)
-
     return Operations(ops, list(old))

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -265,7 +265,10 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         track : T | list[T]
             Track object(s) to insert
         tracks_before : list[T]
-            List of tracks before changes applied.
+            List of all tracks in the playlist insert is applied.
+            We need this argument because the apis of some services do not use indices
+            to reference tracks in the playlist (therefore we need this as a helper
+            to work with old_ and nex_idx consistently across services)
         """
         ...
 
@@ -285,7 +288,10 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         track : T
             Track being deleted
         tracks_before : list[T]
-            List of tracks before deletion.
+            List of all tracks in the playlist before deletion.
+            We need this argument because the apis of some services do not use indices
+            to reference tracks in the playlist (therefore we need this as a helper
+            to work with old_ and nex_idx consistently across services)
         """
         ...
 
@@ -298,6 +304,9 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
     ) -> None:
         """Move track from old_idx to new_idx remotely.
 
+        Does not support batch operations, since it would be unclear in which order
+        moves should be undertaken.
+
         Default: delete then insert. Subclasses may optimize.
 
         Parameters
@@ -308,8 +317,11 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
             Destination index
         track : T
             Track being moved
-        live_list : list[T]
-            List of tracks before move was applied.
+        tracks_before : list[T]
+            List of all tracks in the playlist before move was applied.
+            We need this argument because the apis of some services do not use indices
+            to reference tracks in the playlist (therefore we need this as a helper
+            to work with old_ and nex_idx consistently across services)
         """
         # Remove from old position
         self._remote_delete_track(old_idx, track, tracks_before)

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -214,13 +214,11 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
                     tracks_before=batch[0].list_before,
                 )
             elif isinstance(batch[0].op, DeleteOp):
-                # FIXME: Implement batched delete
-                for step in batch:
-                    self._remote_delete_track(
-                        idx=step.op.idx,  # type: ignore[attr-defined]
-                        track=step.op.item,
-                        tracks_before=step.list_before,
-                    )
+                self._remote_delete_track(
+                    idx=batch[0].op.idx,
+                    track=[step.op.item for step in batch],
+                    tracks_before=batch[0].list_before,
+                )
             elif isinstance(batch[0].op, MoveOp):
                 # Multi moves at the same time are quite ambiguous
                 for step in batch:
@@ -276,7 +274,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
     def _remote_delete_track(
         self,
         idx: int,
-        track: T,
+        track: T | list[T],
         tracks_before: list[T],
     ) -> None:
         """Delete track at index from remote service.
@@ -285,8 +283,8 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         ----------
         idx : int
             Zero-based index of track to delete
-        track : T
-            Track being deleted
+        track : T | list[T]
+            Track object(s) to delete
         tracks_before : list[T]
             List of all tracks in the playlist before deletion.
             We need this argument because the apis of some services do not use indices

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from typing import Generic, TypedDict
 
 from .collection import Collection, TrackStream, TypeVar
-from .diff import DeleteOp, InsertOp, MoveOp, list_diff
+from .diff import DeleteOp, InsertOp, MoveOp, batch_consecutive, list_diff
 from .track import Track
 
 
@@ -203,15 +203,33 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
             self._remote_update_metadata(new_name, new_description)
 
         operations = list_diff(before.tracks, after.tracks, hash_func=self._track_key)
-        for op in operations:
-            if isinstance(op, InsertOp):
-                self._remote_insert_track(op.idx, op.item, operations.live_list)
-            elif isinstance(op, DeleteOp):
-                self._remote_delete_track(op.idx, op.item, operations.live_list)
-            elif isinstance(op, MoveOp):
-                self._remote_move_track(
-                    op.old_idx, op.new_idx, op.item, operations.live_list
+        for batch in batch_consecutive(operations.iter()):
+            # Batch is always nonempty batch of operation
+            # including consecutive indexes
+            # we can use them here without worry
+            if isinstance(batch[0].op, InsertOp):
+                self._remote_insert_track(
+                    idx=batch[0].op.idx,
+                    track=[step.op.item for step in batch],
+                    tracks_before=batch[0].list_before,
                 )
+            elif isinstance(batch[0].op, DeleteOp):
+                # FIXME: Implement batched delete
+                for step in batch:
+                    self._remote_delete_track(
+                        idx=step.op.idx,  # type: ignore[attr-defined]
+                        track=step.op.item,
+                        tracks_before=step.list_before,
+                    )
+            elif isinstance(batch[0].op, MoveOp):
+                # Multi moves at the same time are quite ambiguous
+                for step in batch:
+                    self._remote_move_track(
+                        old_idx=step.op.old_idx,  # type: ignore[attr-defined]
+                        new_idx=step.op.new_idx,  # type: ignore[attr-defined]
+                        track=step.op.item,
+                        tracks_before=step.list_before,
+                    )
 
     # ---------------------- Abstract remote operations ---------------------- #
 
@@ -235,8 +253,8 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
     def _remote_insert_track(
         self,
         idx: int,
-        track: T,
-        live_list: list[T],
+        track: T | list[T],
+        tracks_before: list[T],
     ) -> None:
         """Insert track at index on remote service.
 
@@ -244,10 +262,10 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         ----------
         idx : int
             Zero-based insertion index (0 <= idx <= current length)
-        track : T
-            Track object to insert
-        live_list : list[T]
-            Current live list
+        track : T | list[T]
+            Track object(s) to insert
+        tracks_before : list[T]
+            List of tracks before changes applied.
         """
         ...
 
@@ -256,7 +274,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         self,
         idx: int,
         track: T,
-        live_list: list[T],
+        tracks_before: list[T],
     ) -> None:
         """Delete track at index from remote service.
 
@@ -266,8 +284,8 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
             Zero-based index of track to delete
         track : T
             Track being deleted
-        live_list : list[T]
-            Current live list
+        tracks_before : list[T]
+            List of tracks before deletion.
         """
         ...
 
@@ -276,7 +294,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         old_idx: int,
         new_idx: int,
         track: T,
-        live_list: list[T],
+        tracks_before: list[T],
     ) -> None:
         """Move track from old_idx to new_idx remotely.
 
@@ -291,15 +309,15 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         track : T
             Track being moved
         live_list : list[T]
-            Current live list
+            List of tracks before move was applied.
         """
         # Remove from old position
-        self._remote_delete_track(old_idx, track, live_list)
-        live_list.pop(old_idx)
+        self._remote_delete_track(old_idx, track, tracks_before)
+        tracks_before.pop(old_idx)
         # Insert at new position (note: new_idx may have shifted due to pop)
         adjusted_new_idx = new_idx if new_idx > old_idx else new_idx
-        self._remote_insert_track(adjusted_new_idx, track, live_list)
-        live_list.insert(adjusted_new_idx, track)
+        self._remote_insert_track(adjusted_new_idx, track, tracks_before)
+        tracks_before.insert(adjusted_new_idx, track)
 
     @abstractmethod
     def _remote_update_metadata(

--- a/plistsync/services/plex/api.py
+++ b/plistsync/services/plex/api.py
@@ -452,6 +452,8 @@ class PlaylistApi:
         """Remove track from playlist.
 
         pl_item_id is not just the ratingKey.
+
+        The plex rest api currently does not support batch deletion.
         """
         response = self.session.request(
             "DELETE",

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -264,10 +264,11 @@ class PlexPlaylistCollection(PlaylistCollection[PlexTrack]):
                     break
 
             if t_data is None:
-                # SM: Maybe we should not raise here
-                raise ValueError(
-                    f"Could not find track data for track id {t.id} in playlist."
+                log.warning(
+                    f"Could not find track data for track id {t.id} in playlist. "
+                    "This should not happen, please consider opening an issue."
                 )
+                continue
 
             pl_item_id = cast(int, t_data.get("playlistItemID", -1))
             self.api.playlist.remove_track(self.id, pl_item_id)

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -221,24 +221,29 @@ class PlexPlaylistCollection(PlaylistCollection[PlexTrack]):
     def _remote_insert_track(
         self,
         idx: int,
-        track: PlexTrack,
-        live_list: list[PlexTrack],
+        track: PlexTrack | list[PlexTrack],
+        tracks_before: list[PlexTrack],
     ) -> None:
-        log.debug(f"Inserting track {track.id} (idx {idx} ignored)")
         if self.id is None:
             raise ValueError("Playlist must be online to call remote insert!")
 
-        self.api.playlist.add_tracks(playlist_id=self.id, item_ids=[track.id])
+        if not isinstance(track, list):
+            track = [track]
+
+        self.api.playlist.add_tracks(
+            playlist_id=self.id, item_ids=[t.id for t in track]
+        )
         self._refetch_tracks()
 
         # we always insert at the end, move to the right spot
-        self._remote_move_track(-1, idx, track, live_list)
+        for i, t in enumerate(track):
+            self._remote_move_track(-1 - i, idx, t, tracks_before)
 
     def _remote_delete_track(
         self,
         idx: int,
         track: PlexTrack,
-        live_list: list[PlexTrack],
+        tracks_before: list[PlexTrack],
     ):
         """
         Delete Track from playlists.
@@ -263,7 +268,7 @@ class PlexPlaylistCollection(PlaylistCollection[PlexTrack]):
         old_idx: int,
         new_idx: int,
         track: PlexTrack,
-        live_list: list[PlexTrack],
+        tracks_before: list[PlexTrack],
     ) -> None:
         """
         Move track in a playlist.

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -242,7 +242,7 @@ class PlexPlaylistCollection(PlaylistCollection[PlexTrack]):
     def _remote_delete_track(
         self,
         idx: int,
-        track: PlexTrack,
+        track: PlexTrack | list[PlexTrack],
         tracks_before: list[PlexTrack],
     ):
         """
@@ -250,17 +250,27 @@ class PlexPlaylistCollection(PlaylistCollection[PlexTrack]):
 
         Plex does not allow duplicate items in playlists.
         """
-        log.debug(f"Deleting track {track.id} (idx {idx} ignored)")
         if self.id is None or not isinstance(self.data, PlexPlaylistOnlineData):
             raise ValueError("Playlist must be online to call remote delete!")
 
-        t_data = self.data.tracks_data[idx]
-        if not t_data.get("ratingKey") == track.id:
-            raise ValueError(f"Key mismatch for {idx=} vs {track=}")
+        if not isinstance(track, list):
+            track = [track]
 
-        # PS 2026-02-17: so it PlexPlaylistTrack does make sense, after all ...
-        pl_item_id = cast(int, t_data.get("playlistItemID", -1))
-        self.api.playlist.remove_track(self.id, pl_item_id)
+        for t in track:
+            t_data = None
+            for td in self.data.tracks_data:
+                if td.get("ratingKey") == t.id:
+                    t_data = td
+                    break
+
+            if t_data is None:
+                # SM: Maybe we should not raise here
+                raise ValueError(
+                    f"Could not find track data for track id {t.id} in playlist."
+                )
+
+            pl_item_id = cast(int, t_data.get("playlistItemID", -1))
+            self.api.playlist.remove_track(self.id, pl_item_id)
         self._refetch_tracks()
 
     def _remote_move_track(

--- a/plistsync/services/spotify/playlist.py
+++ b/plistsync/services/spotify/playlist.py
@@ -211,12 +211,15 @@ class SpotifyPlaylistCollection(PlaylistCollection[SpotifyPlaylistTrack]):
     def _remote_delete_track(
         self,
         idx: int,
-        track: SpotifyPlaylistTrack,
+        track: SpotifyPlaylistTrack | list[SpotifyPlaylistTrack],
         tracks_before: list[SpotifyPlaylistTrack],
     ):
         if not self.id:
             raise ValueError("Id must be set to call remote delete!")
-        self.api.playlist.remove_tracks(self.id, [track.uri], [idx])
+        track_uris = [t.uri for t in track] if isinstance(track, list) else [track.uri]
+        self.api.playlist.remove_tracks(
+            self.id, track_uris, [i for i in range(idx, idx - len(track_uris), -1)]
+        )
 
     def _remote_move_track(
         self,

--- a/plistsync/services/spotify/playlist.py
+++ b/plistsync/services/spotify/playlist.py
@@ -199,18 +199,20 @@ class SpotifyPlaylistCollection(PlaylistCollection[SpotifyPlaylistTrack]):
     def _remote_insert_track(
         self,
         idx: int,
-        track: SpotifyPlaylistTrack,
-        live_list: list[SpotifyPlaylistTrack],
+        track: SpotifyPlaylistTrack | list[SpotifyPlaylistTrack],
+        tracks_before: list[SpotifyPlaylistTrack],
     ) -> None:
         if not self.id:
             raise ValueError("Id must be set to call remote insert!")
-        self.api.playlist.add_tracks(self.id, [track.uri], idx)
+
+        track_uris = [t.uri for t in track] if isinstance(track, list) else [track.uri]
+        self.api.playlist.add_tracks(self.id, track_uris, idx)
 
     def _remote_delete_track(
         self,
         idx: int,
         track: SpotifyPlaylistTrack,
-        live_list: list[SpotifyPlaylistTrack],
+        tracks_before: list[SpotifyPlaylistTrack],
     ):
         if not self.id:
             raise ValueError("Id must be set to call remote delete!")
@@ -221,7 +223,7 @@ class SpotifyPlaylistCollection(PlaylistCollection[SpotifyPlaylistTrack]):
         old_idx: int,
         new_idx: int,
         track: SpotifyPlaylistTrack,
-        live_list: list[SpotifyPlaylistTrack],
+        tracks_before: list[SpotifyPlaylistTrack],
     ) -> None:
         if not self.id:
             raise ValueError("Id must be set to call remote move!")

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Hashable
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Self, cast
 
 from plistsync.core.playlist import PlaylistCollection, PlaylistInfo, Snapshot
 from plistsync.logger import log
@@ -220,20 +220,23 @@ class TidalPlaylistCollection(PlaylistCollection[TidalPlaylistTrack]):
     def _remote_delete_track(
         self,
         idx: int,
-        track: TidalPlaylistTrack,
+        track: TidalPlaylistTrack | list[TidalPlaylistTrack],
         tracks_before: list[TidalPlaylistTrack],
     ) -> None:
         if not self.id:
             raise ValueError("Id must be set to call remote delete!")
 
+        if not isinstance(track, list):
+            track = [track]
+
         # Realistically this should never be unset if we want to remove the track
-        if not track.item_id:
+        if not all(t.item_id for t in track):
             raise ValueError("ItemID must be set in track should be removed!")
 
         # Deletion is done via itemId (unique in playlist)
         self.api.playlist.remove_items(
             playlist_id=self.id,
-            item_ids=[(track.id, track.item_id)],
+            item_ids=[(t.id, cast(str, t.item_id)) for t in track],
         )
 
     def _remote_update_metadata(

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -231,7 +231,7 @@ class TidalPlaylistCollection(PlaylistCollection[TidalPlaylistTrack]):
 
         # Realistically this should never be unset if we want to remove the track
         if not all(t.item_id for t in track):
-            raise ValueError("ItemID must be set in track should be removed!")
+            raise ValueError("ItemID must be set in every track we want to remove!")
 
         # Deletion is done via itemId (unique in playlist)
         self.api.playlist.remove_items(

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -199,29 +199,29 @@ class TidalPlaylistCollection(PlaylistCollection[TidalPlaylistTrack]):
     def _remote_insert_track(
         self,
         idx: int,
-        track: TidalPlaylistTrack,
-        live_list: list[TidalPlaylistTrack],
+        track: TidalPlaylistTrack | list[TidalPlaylistTrack],
+        tracks_before: list[TidalPlaylistTrack],
     ) -> None:
         if not self.id:
             raise ValueError("Id must be set to call remote insert!")
-        # Live list includes current operation
-        if idx + 1 >= len(live_list):
+        track_ids = [t.id for t in track] if isinstance(track, list) else [track.id]
+        if idx >= len(tracks_before):
             self.api.playlist.add_items(
                 playlist_id=self.id,
-                ids=[track.id],
+                ids=track_ids,
             )
         else:
             self.api.playlist.add_items(
                 playlist_id=self.id,
-                ids=[track.id],
-                position_before=live_list[idx + 1].item_id,
+                ids=track_ids,
+                position_before=tracks_before[idx].item_id,
             )
 
     def _remote_delete_track(
         self,
         idx: int,
         track: TidalPlaylistTrack,
-        live_list: list[TidalPlaylistTrack],
+        tracks_before: list[TidalPlaylistTrack],
     ) -> None:
         if not self.id:
             raise ValueError("Id must be set to call remote delete!")

--- a/tests/abc.py
+++ b/tests/abc.py
@@ -463,6 +463,8 @@ class PlaylistCollectionTestBase(ABC):
         pl._apply_diff(before, after)
 
         pl._remote_update_metadata.assert_not_called()
-        pl._remote_insert_track.assert_called_once_with(0, t1, ANY)
+        pl._remote_insert_track.assert_called_once_with(
+            idx=0, track=[t1], tracks_before=ANY
+        )
         pl._remote_delete_track.assert_not_called()
         pl._remote_move_track.assert_not_called()

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -24,11 +24,29 @@ class MockPlaylist(PlaylistCollection):
     def info(self, value: PlaylistInfo):
         self._info = value
 
-    def _remote_delete_track(self, idx: int, track, live_list) -> None:
-        self.log.append(("delete", idx, track))
+    def _remote_delete_track(
+        self,
+        idx: int,
+        track,
+        tracks_before,
+    ) -> None:
+        if isinstance(track, list):
+            for t in track:
+                self.log.append(("delete", idx, t))
+        else:
+            self.log.append(("delete", idx, track))
 
-    def _remote_insert_track(self, idx: int, track, live_list) -> None:
-        self.log.append(("insert", idx, track))
+    def _remote_insert_track(
+        self,
+        idx: int,
+        track,
+        tracks_before,
+    ) -> None:
+        if isinstance(track, list):
+            for t in track:
+                self.log.append(("insert", idx, t))
+        else:
+            self.log.append(("insert", idx, track))
 
     def _remote_update_metadata(
         self, new_name: str | None = None, new_description: str | None = None

--- a/tests/core/test_diff.py
+++ b/tests/core/test_diff.py
@@ -1,12 +1,18 @@
 import pytest
 
-from plistsync.core.diff import DeleteOp, InsertOp, MoveOp, Operations, list_diff
+from plistsync.core.diff import (
+    DeleteOp,
+    InsertOp,
+    MoveOp,
+    Operations,
+    batch_consecutive,
+    list_diff,
+)
 
 
 class TestPlaylistDiff:
-    """Test suif for the playlist_diff function."""
+    """Test suite for the playlist_diff function."""
 
-    # fmt: off
     @pytest.mark.parametrize(
         "old, new, expected",
         [
@@ -19,7 +25,7 @@ class TestPlaylistDiff:
             pytest.param([], ["B", "B"], [InsertOp(idx=0, item="B"), InsertOp(idx=1, item="B")], id="insert_two_duplicates"),
             pytest.param(["A"], ["A", "A"], [InsertOp(idx=1, item="A")], id="insert_duplicate_after"),
             pytest.param(["A", "B", "C"], ["A", "B", "B", "C"], [InsertOp(idx=2, item="B")], id="insert_duplicate_in_middle"),
-            # Delets
+            # Deletes
             pytest.param(["A"], [], [DeleteOp(idx=0, item="A")], id="delete_single"),
             pytest.param(["A", "A"], ["A"], [DeleteOp(idx=1, item="A")], id="delete_duplicate"),
             pytest.param(["A", "B", "C"], ["A", "C"], [DeleteOp(idx=1, item="B")], id="delete_middle"),
@@ -73,16 +79,20 @@ class TestPlaylistDiff:
                 [MoveOp(old_idx=1, new_idx=0, item="B")],
                 id="swap_two",
             ),
+       
         ],
-    )
+   
+    )  # fmt: skip
     def test_playlist_diff(self, old, new, expected):
         """Comprehensive test suite for playlist_diff."""
         ops = list_diff(old, new, lambda x: x)
-        assert list(ops) == expected, f"Expected {expected}, got {ops}"
+        applied_ops = [op.op for op in ops.iter()]
+        assert applied_ops == expected, f"Expected {expected}, got {ops}"
 
         # Verify round-trip
         playlist = old.copy()
-        for op in list(ops):
+        for step in ops.iter():
+            op = step.op
             if isinstance(op, DeleteOp):
                 # Remove the item at the index
                 playlist.pop(op.idx)
@@ -96,8 +106,6 @@ class TestPlaylistDiff:
             else:
                 raise ValueError(f"Unknown operation: {op}")
         assert playlist == new, f"Failed to reconstruct: {playlist} != {new}"
-
-    # fmt: on
 
     @pytest.mark.parametrize(
         "old, ops_list, expected_applied_ops",
@@ -140,7 +148,7 @@ class TestPlaylistDiff:
     def test_operations_redundant(self, old, ops_list, expected_applied_ops):
         """Test that Operations.__iter__ skips redundant or impossible actions."""
         ops = Operations(ops_list, old_list=old)
-        applied_ops = list(ops)
+        applied_ops = [op.op for op in ops.iter()]
         assert applied_ops == expected_applied_ops
 
     def test_operations_indexing(self):
@@ -154,3 +162,64 @@ class TestPlaylistDiff:
 
         for i, op in enumerate(ops.ops):
             assert ops[i] == op
+
+
+class TestBatchConsecutive:
+    @pytest.mark.parametrize(
+        ["old", "new", "expected_batches"],
+        [
+            # Consecutive inserts -> single batch
+            (
+                ["A", "B"],
+                ["A", "B", "C", "D"],
+                [
+                    [InsertOp("C", 2), InsertOp("D", 3)],
+                ],
+            ),
+            # Non-consecutive inserts -> separate batches
+            (
+                ["A", "B"],
+                ["A", "C", "B", "D"],
+                [
+                    [InsertOp("C", 1)],
+                    [InsertOp("D", 3)],
+                ],
+            ),
+            # Consecutive deletes -> single batch
+            (
+                ["A", "B", "C"],
+                [],
+                [
+                    [DeleteOp("C", 2), DeleteOp("B", 1), DeleteOp("A", 0)],
+                ],
+            ),
+            # Different types -> separate batches
+            (
+                ["A", "B", "C"],
+                ["A", "D", "C"],
+                [
+                    [DeleteOp("B", 1)],
+                    [InsertOp("D", 1)],
+                ],
+            ),
+            # Moves -> each in own batch
+            (
+                ["A", "B", "C"],
+                ["B", "A", "C"],
+                [
+                    [MoveOp(old_idx=1, new_idx=0, item="B")],
+                ],
+            ),
+            # No changes
+            (
+                ["A", "B"],
+                ["A", "B"],
+                [],
+            ),
+        ],
+    )
+    def test_batch(self, old, new, expected_batches):
+        ops = list_diff(old, new, lambda x: x)
+        batch_steps = list(batch_consecutive(ops.iter()))
+        batch_ops = list(map(lambda x: [i.op for i in x], batch_steps))
+        assert batch_ops == expected_batches


### PR DESCRIPTION
Add batched remote operations for consecutive inserts

This PR adds support for batching consecutive remote operations to reduce
network requests. For example, inserting multiple tracks at consecutive
positions (e.g., positions 3, 4, 5) can now be done in a single API call
instead of three separate calls.

Changes:
- Add `BaseOp` base class and `Step` wrapper for operations
- Add `batch_consecutive()` to group consecutive ops of same type
- Update `PlaylistCollection._apply_diff` to use batching
- Update Spotify/Tidal implementations to handle batched inserts

closes #35 