### PR TITLE
Added `--version` and auth command reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+- Auth commands are now available via `plistsync auth [service]` instead of `plistsync [service] auth`
+- Added `plistsync --version` command to show the currently installed version of the library
+
 ## [0.5.1] - 2026-03-16
 
 ### Fixed
@@ -34,8 +39,6 @@ We encourage early adopters to:
 
 - Unified `__repr__` format across all core classes to `ClassName(key=value)` for consistent, debug-friendly output.
 - Standardized `get_playlist()` behavior across all services: now consistently returns `None` when no playlist is found, regardless of the lookup identifier used. Introduced `get_playlist_or_raise()` for predictable, exception-raising behavior when a playlist _must_ exist.
-- Auth commands are now available via `plistsync auth [service]` instead of `plistsync [service] auth`
-- Added `plistsync --version` command to show the currently installed version of the library
 
 ## [0.4.0] - 2026-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ We encourage early adopters to:
 
 - Unified `__repr__` format across all core classes to `ClassName(key=value)` for consistent, debug-friendly output.
 - Standardized `get_playlist()` behavior across all services: now consistently returns `None` when no playlist is found, regardless of the lookup identifier used. Introduced `get_playlist_or_raise()` for predictable, exception-raising behavior when a playlist _must_ exist.
+- Auth commands are now available via `plistsync auth [service]` instead of `plistsync [service] auth`
+- Added `plistsync --version` command to show the currently installed version of the library
 
 ## [0.4.0] - 2026-03-07
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,10 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+import os
+import sys
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "services"))  # noqa: PTH118, PTH120
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/docs/services/cli.py
+++ b/docs/services/cli.py
@@ -1,0 +1,17 @@
+import typer
+
+from plistsync.services.plex.authenticate import auth as plex_auth
+from plistsync.services.spotify.authenticate import auth as spotify_auth
+from plistsync.services.tidal.authenticate import auth as tidal_auth
+
+# Wrapper for cli auth commands
+
+app = typer.Typer(name="auth", add_completion=False)
+
+app.command(name="tidal")(tidal_auth)
+app.command(name="spotify")(spotify_auth)
+app.command(name="plex")(plex_auth)
+
+
+if __name__ == "__main__":
+    app()

--- a/docs/services/plex/getting-started.md
+++ b/docs/services/plex/getting-started.md
@@ -52,7 +52,7 @@ services:
 Once configured, authenticate `plistsync` with your Plex account:
 
 ```bash
-plistsync plex auth
+plistsync auth plex
 ```
 
 This will start an interactive authentication flow:
@@ -66,9 +66,9 @@ This will start an interactive authentication flow:
 
 <div class="only-light">
 
-```{typer} plistsync.services.plex.authenticate:plex_cli
+```{typer} cli:app::plex
 ---
-prog: plistsync plex auth
+prog: plistsync auth plex
 theme: light
 width: 80
 ---
@@ -78,9 +78,9 @@ width: 80
 
 <div class="only-dark">
 
-```{typer} plistsync.services.plex.authenticate:plex_cli
+```{typer} cli:app::plex
 ---
-prog: plistsync plex auth
+prog: plistsync auth plex
 theme: dark
 width: 80
 ---

--- a/docs/services/spotify/getting-started.md
+++ b/docs/services/spotify/getting-started.md
@@ -61,7 +61,7 @@ services:
 Once configured, authenticate `plistsync` with your Tidal account:
 
 ```bash
-plistsync spotify auth
+plistsync auth spotify
 ```
 
 This will start an interactive authentication flow:
@@ -75,9 +75,9 @@ This will start an interactive authentication flow:
 
 <div class="only-light">
 
-```{typer} plistsync.services.spotify.authenticate:spotify_cli
+```{typer} cli:app::spotify
 ---
-prog: plistsync spotify auth
+prog: plistsync auth spotify
 theme: light
 width: 80
 ---
@@ -87,9 +87,9 @@ width: 80
 
 <div class="only-dark">
 
-```{typer} plistsync.services.spotify.authenticate:spotify_cli
+```{typer} cli:app::spotify
 ---
-prog: plistsync spotify auth
+prog: plistsync auth spotify
 theme: dark
 width: 80
 ---

--- a/docs/services/tidal/getting-started.md
+++ b/docs/services/tidal/getting-started.md
@@ -61,7 +61,7 @@ services:
 Once configured, authenticate `plistsync` with your Tidal account:
 
 ```bash
-plistsync tidal auth
+plistsync auth tidal
 ```
 
 This will start an interactive authentication flow:
@@ -75,9 +75,9 @@ This will start an interactive authentication flow:
 
 <div class="only-light">
 
-```{typer} plistsync.services.tidal.authenticate:tidal_cli
+```{typer} cli:app::tidal
 ---
-prog: plistsync tidal auth
+prog: plistsync auth tidal
 theme: light
 width: 80
 ---
@@ -87,9 +87,9 @@ width: 80
 
 <div class="only-dark">
 
-```{typer} plistsync.services.tidal.authenticate:tidal_cli
+```{typer} cli:app::tidal
 ---
-prog: plistsync tidal auth
+prog: plistsync auth tidal
 theme: dark
 width: 80
 ---

--- a/plistsync/__main__.py
+++ b/plistsync/__main__.py
@@ -15,44 +15,47 @@ cli = typer.Typer(
     rich_markup_mode="rich",
     help="Command line tool for [bold italic]plistsync[/bold italic].",
     pretty_exceptions_show_locals=False,
+    no_args_is_help=True,
 )
 
 
-def register_apps(cli: typer.Typer):
-    """Register subcommands.
+def register_auth(cli: typer.Typer):
+    """Register authentication subcommands.
 
-    To allow partial dependencies we only register cli if the import is sucessfull.
+    To allow partial dependencies we only register cli if the import is successful.
     """
 
+    auth_app = typer.Typer(
+        name="auth",
+        help="Authentication for services.",
+        no_args_is_help=True,
+    )
+
+    # Register auth su
     imports_ = {
-        "plistsync.services.plex.authenticate": "plex_cli",
-        "plistsync.services.spotify.authenticate": "spotify_cli",
-        "plistsync.services.tidal.authenticate": "tidal_cli",
+        "plistsync.services.plex.authenticate:auth": "plex",
+        "plistsync.services.spotify.authenticate:auth": "spotify",
+        "plistsync.services.tidal.authenticate:auth": "tidal",
     }
 
-    for module_name, obj_name in imports_.items():
+    for module_str, name in imports_.items():
+        module_name, func_name = module_str.split(":")
         try:
             module = importlib.import_module(module_name)
-            cli.add_typer(getattr(module, obj_name), name=obj_name.replace("_cli", ""))
+            auth_app.command(name=name)(getattr(module, func_name))
         except DependencyError:
-            # TODO: register subcommand (should not be shown in help)
-            # prints message how to install service
             log.debug(
-                f"Skipping '{module_name}.{obj_name}' due to missing dependencies."
+                f"Skipping '{module_name}.{func_name}' due to missing dependencies."
             )
 
+    cli.add_typer(auth_app)
 
-register_apps(cli)
+
+register_auth(cli)
 cli.add_typer(create_config_cli(Config), name="config")
 
 
-# Add global verbose option
-@cli.callback()
-def logging_setup(
-    verbose: int = typer.Option(
-        -1, "--verbose", "-v", count=True, help="Increase verbosity."
-    ),
-) -> None:
+def logging_callback(verbose: int) -> None:
     level_mapping: dict[int, int] = {
         1: logging.INFO,
         2: logging.DEBUG,
@@ -60,7 +63,7 @@ def logging_setup(
     }
     level = level_mapping.get(verbose)
     if level is None:
-        return
+        return None
 
     # Only adjust levels; logging handlers were already configured at import time.
     set_log_level(level)
@@ -82,7 +85,7 @@ def logging_setup(
         None,
     )
     if handler is None:
-        return
+        return None
 
     if verbose >= 2:
         handler._log_render.show_path = True
@@ -96,6 +99,43 @@ def logging_setup(
         handler.setFormatter(logging.Formatter("%(name)-12s %(message)s"))
 
     log.debug("Adjusted log level to %s", logging.getLevelName(level))
+
+
+def version_callback(value: bool) -> None:
+    if not value:
+        return None
+
+    from importlib.metadata import version
+
+    from .services import available_services
+
+    ver = version("plistsync")
+    services = [service.name.split(".")[-1] for service in available_services()]
+
+    svc_str = ", ".join(services) if services else "none"
+    typer.echo(f"plistsync: {ver}  ({svc_str})")
+    raise typer.Exit()
+
+
+@cli.callback()
+def main(
+    ctx: typer.Context,
+    verbose: int | None = typer.Option(
+        None,
+        "--verbose",
+        "-v",
+        count=True,
+        callback=logging_callback,
+        help="Increase verbosity.",
+    ),
+    version: bool | None = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        help="Currently installed version.",
+    ),
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/plistsync/services/__init__.py
+++ b/plistsync/services/__init__.py
@@ -1,3 +1,27 @@
-# Empty init file here allows us to have different subdependencies
-# for the services.
-# We raise with check_dependencies
+# We do not import from the different submodules as they
+# might raise with check_dependencies.
+
+import importlib
+import pkgutil
+from functools import cache
+
+from plistsync.errors import DependencyError
+
+
+@cache
+def available_services() -> list[pkgutil.ModuleInfo]:
+    """Get the available services.
+
+    Skips modules where dependencies are missing.
+    """
+    valid_services = []
+    for module_info in pkgutil.iter_modules(__path__, __name__ + "."):
+        try:
+            # Test import - catches missing deps (beets, plex, etc.)
+            importlib.import_module(module_info.name)
+            valid_services.append(module_info)
+        except DependencyError:
+            # Skip services with missing dependencies
+            pass
+
+    return valid_services

--- a/plistsync/services/plex/authenticate.py
+++ b/plistsync/services/plex/authenticate.py
@@ -11,12 +11,7 @@ from plistsync.errors import AuthenticationError
 from plistsync.logger import log
 from plistsync.utils.auth.redirect import BaseRedirectHandler
 
-plex_cli = typer.Typer(
-    rich_markup_mode="rich", help="Interact with Plex.", add_completion=False
-)
 
-
-@plex_cli.command()
 def auth(
     mode: Literal["forward", "polling"] = typer.Option(
         "forward",

--- a/plistsync/services/spotify/authenticate.py
+++ b/plistsync/services/spotify/authenticate.py
@@ -15,11 +15,6 @@ from plistsync.logger import log
 from plistsync.utils import build_url
 from plistsync.utils.auth.bearer_token import BearerToken
 
-spotify_cli = typer.Typer(
-    rich_markup_mode="rich", help="Interact with Spotify.", add_completion=False
-)
-
-
 SCOPES = " ".join(
     [
         "playlist-read-private",
@@ -30,7 +25,6 @@ SCOPES = " ".join(
 )
 
 
-@spotify_cli.command()
 def auth(
     mode: Literal["forward", "manual"] = typer.Option(
         "forward",

--- a/plistsync/services/tidal/authenticate.py
+++ b/plistsync/services/tidal/authenticate.py
@@ -15,10 +15,6 @@ from plistsync.logger import log
 from plistsync.utils import build_url
 from plistsync.utils.auth.bearer_token import BearerToken
 
-tidal_cli = typer.Typer(
-    rich_markup_mode="rich", help="Interact with Tidal.", add_completion=False
-)
-
 SCOPES = " ".join(
     [
         "playlists.read",
@@ -31,7 +27,6 @@ SCOPES = " ".join(
 )
 
 
-@tidal_cli.command()
 def auth(
     mode: Literal["forward", "manual"] = typer.Option(
         "forward",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ docs = [
     "sphinx-autoapi>=3.6.1",
     "sphinx-design>=0.6.1",
     "sphinx-copybutton>=0.5.2",
-    "sphinxcontrib-typer[html]>=0.7.2",
+    "sphinxcontrib-typer[html]>=0.8.1",
     "sphinxcontrib-mermaid>=2.0.0",
 ]
 typed = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,12 @@ class TestCliInvocation:
         assert result.exit_code == 0
         assert "config" in result.output.lower()
 
+    def test_version(self):
+        """Test that config subcommand shows help."""
+        result = runner.invoke(main.cli, ["--version"])
+        assert result.exit_code == 0
+        assert "plistsync" in result.output.lower()
+
 
 class TestLoggingSetup:
     """Test the logging_setup callback function."""
@@ -33,40 +39,37 @@ class TestLoggingSetup:
     def test_verbose_flag_level_1(self, plist_config):
         """Test that -v sets log level to INFO."""
         with patch("plistsync.__main__.set_log_level") as mock_set_level:
-            main.logging_setup(verbose=1)
+            main.logging_callback(verbose=1)
             mock_set_level.assert_called_once_with(20)
 
     def test_verbose_flag_level_2(self, plist_config):
         """Test that -vv sets log level to DEBUG."""
         with patch("plistsync.__main__.set_log_level") as mock_set_level:
-            main.logging_setup(verbose=2)
+            main.logging_callback(verbose=2)
             mock_set_level.assert_called_once_with(10)
 
     def test_verbose_flag_level_3(self, plist_config):
         """Test that -vvv sets log level to DEBUG."""
         with patch("plistsync.__main__.set_log_level") as mock_set_level:
-            main.logging_setup(verbose=3)
+            main.logging_callback(verbose=3)
             mock_set_level.assert_called_once_with(10)
 
     def test_verbose_flag_zero(self, plist_config):
         """Test that no -v flag returns None without setting level."""
         with patch("plistsync.__main__.set_log_level") as mock_set_level:
-            result = main.logging_setup(verbose=0)
-            assert result is None
+            main.logging_callback(verbose=0)
             mock_set_level.assert_not_called()
 
     def test_verbose_flag_negative(self, plist_config):
         """Test that negative verbose returns None without setting level."""
         with patch("plistsync.__main__.set_log_level") as mock_set_level:
-            result = main.logging_setup(verbose=-1)
-            assert result is None
+            main.logging_callback(verbose=-1)
             mock_set_level.assert_not_called()
 
     def test_verbose_over_max(self, plist_config):
         """Test that verbose > 3 returns None without setting level."""
         with patch("plistsync.__main__.set_log_level") as mock_set_level:
-            result = main.logging_setup(verbose=10)
-            assert result is None
+            main.logging_callback(verbose=10)
             mock_set_level.assert_not_called()
 
 
@@ -79,7 +82,7 @@ class TestRegisterApps:
             mock_module = MagicMock()
             mock_import.return_value = mock_module
 
-            main.register_apps(main.cli)
+            main.register_auth(main.cli)
 
             assert mock_import.call_count >= 3
 
@@ -97,6 +100,6 @@ class TestRegisterApps:
                 DependencyError("test", ["test-package"]),
             ]
 
-            main.register_apps(main.cli)
+            main.register_auth(main.cli)
 
             assert mock_log.debug.call_count >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1925,7 +1934,7 @@ dev = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinxcontrib-mermaid", specifier = ">=2.0.0" },
-    { name = "sphinxcontrib-typer", extras = ["html"], specifier = ">=0.7.2" },
+    { name = "sphinxcontrib-typer", extras = ["html"], specifier = ">=0.8.1" },
     { name = "tinytag", specifier = ">=2.2.0" },
     { name = "types-lxml", specifier = ">=2026.1.1" },
     { name = "types-requests", specifier = ">=2.32.4.20260107" },
@@ -1940,7 +1949,7 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinxcontrib-mermaid", specifier = ">=2.0.0" },
-    { name = "sphinxcontrib-typer", extras = ["html"], specifier = ">=0.7.2" },
+    { name = "sphinxcontrib-typer", extras = ["html"], specifier = ">=0.8.1" },
 ]
 lint = [
     { name = "nbconvert" },
@@ -2786,15 +2795,15 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-typer"
-version = "0.7.2"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
-    { name = "typer-slim", extra = ["standard"] },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/cc/bbcc7e53406cdc8b0d811187d4ea0bd4f44a1edc661ef2837bf77710ee4a/sphinxcontrib_typer-0.7.2.tar.gz", hash = "sha256:1ae59bb3a599d263468a2bf854748a8ed07ebd5c90045f641b99867f157a92b8", size = 377299, upload-time = "2025-12-23T06:19:35.966Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/17/7e07799e1df369c170e747f8866b80563ff88d385f14304f8891a9f0fe4e/sphinxcontrib_typer-0.8.1.tar.gz", hash = "sha256:223016757b3ab1995971fce048ed5e939b4fd45ca0c255e320e0f87d04dbf9ef", size = 228669, upload-time = "2026-03-06T00:43:01.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/0d/15a3111b3dda6453efab021c347645b7fe1a9feb73f51b6992ace2a4e350/sphinxcontrib_typer-0.7.2-py3-none-any.whl", hash = "sha256:334f5d84c616b476336c0024f5a67d8f8b0125737892c14337d76773ff4f66ac", size = 14524, upload-time = "2025-12-23T06:19:34.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/30/715e975d6e0b47979d37dab9fca05d8a178e45384d6f44fbf7ec76368220/sphinxcontrib_typer-0.8.1-py3-none-any.whl", hash = "sha256:869a69caf367af94e4acf2cfd62ce8b87faa02831c3d68c5fb1c96cc6b5dac2a", size = 14711, upload-time = "2026-03-06T00:42:59.781Z" },
 ]
 
 [package.optional-dependencies]
@@ -3004,36 +3013,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.21.1"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.21.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
-]
-
-[package.optional-dependencies]
-standard = [
-    { name = "rich" },
-    { name = "shellingham" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Inverted the ordering around the auth commands:
```bash
# before
plistsync [service] auth
# after
plistsync auth [service]
```

Added `--version` callback:
```bash
plistsync --version                                                                                                                                                            
> plistsync: 0.4.0  (beets, local, plex, spotify, tidal)
```
