### PR TITLE
Split apply diff (new _remote_commit).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auth commands are now available via `plistsync auth [service]` instead of `plistsync [service] auth`
 - Added `plistsync --version` command to show the currently installed version of the library
+- Renamed `_apply_diff` -> `_remote_commit` for clarity
+- Moved incremental-track abstract methods into a separate class (`IncrementalPlaylistCollection`). This separation allows services to use simpler implementations when the API supports full playlist updates without intermediate steps.
 
 ## [0.5.1] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auth commands are now available via `plistsync auth [service]` instead of `plistsync [service] auth`
 - Added `plistsync --version` command to show the currently installed version of the library
 - Renamed `_apply_diff` -> `_remote_commit` for clarity
-- Moved incremental-track abstract methods into a separate class (`IncrementalPlaylistCollection`). This separation allows services to use simpler implementations when the API supports full playlist updates without intermediate steps.
+- Split Playlist ABC into two classes: one for simple services, like filesystems, where states can be pushed via a single API call (`PlaylistCollection`) and one where multiple API calls are required (`MultiRequestPlaylistCollection`), e.g. when a playlists description cannot be pushed in the same call as track changes.
 
 ## [0.5.1] - 2026-03-16
 

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -15,8 +15,6 @@ the required methods.
 .. code-block:: python
 
     class MyPlaylistCollection(PlaylistCollection):
-
-
 """
 
 from __future__ import annotations
@@ -56,8 +54,29 @@ class Snapshot(Generic[T]):
 class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
     """Abstract base class for playlist collections across music services.
 
-    Manages local track state and syncs changes to remote services via concrete
-    subclasses. Supports transactional edits through the `edit()` context manager.
+    Manages local track state and syncs changes to remote services.
+
+    It supports two ways to synchronize the local state of a playlist to its remote:
+        - via context manager `with remote_edit():`
+            where we create a snapshot before an after the context, so that we can
+            easily undo failed remote operations
+        - via final call to `remote_upsert()`
+            which checks the remote state and sets it to the current local state
+            (and might internally use the context manager)
+
+    Note:
+    The difference between this base class and IncrementalPlaylistCollection is that
+    here we focus on playlist creation/deletion and services where the playlist state
+    can be saved to remote via a single API call.
+
+    Subclass this and implement:
+        - info (getter / setter)  - Consistent interface for name and description
+        - remote_associated()     - Indicate whether the playlist exists on the remote
+        - _remote_create()        - Create this playlist on the remote
+        - _remote_delete()        - Delete this playlist from the remote
+        - _remote_commit()        - Sync current local state of playlist to the remote
+                                    (usually via single API call)
+
     """
 
     @property
@@ -136,6 +155,10 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         Captures snapshot before entering block. Applies diff to remote service
         on successful exit. Resets local state on error.
         """
+        # Main use case is for roll backs of IncrementalPlaylistCollection, where
+        # individual remote operations might fail.
+        # But we want a consistent interface, therefore we define it in this base class,
+        # even though roll-backs are an uncommon requirement for local changes.
         if not self.remote_associated:
             raise ValueError(
                 "remote_edit() is only supported for playlists that have "
@@ -147,7 +170,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         try:
             yield
             snapshot_after = self.get_snapshot()
-            self._remote_edit(snapshot_before, snapshot_after)
+            self._remote_commit(snapshot_before, snapshot_after)
         except Exception:
             self.tracks = snapshot_before.tracks
             self.name = snapshot_before.name
@@ -185,7 +208,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
 
     def remote_upsert(self):
         """
-        Alternate usage pattern, besides playlist.remote_edit().
+        Alternate usage pattern, besides `with playlist.remote_edit()`.
 
         - if does not exist, create_online()
         - if exists, then invoke remote_edit() wrapper.
@@ -211,31 +234,31 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         ...
 
     @abstractmethod
-    def _remote_edit(self, before: Snapshot[T], after: Snapshot[T]) -> None:
-        """Edit the playlist online."""
+    def _remote_commit(self, before: Snapshot[T], after: Snapshot[T]) -> None:
+        """Write the current playlist state to its online version."""
         ...
 
 
-class IncrementalPlaylistCollection(PlaylistCollection[T], ABC):
-    """Playlist editor for services with single-track API operations.
-
-    Some music services only allow adding/removing one track
-    at a time. This class computes the diff between two playlist states and
-    translates it into the appropriate sequence of remote API calls.
+class MultiRequestPlaylistCollection(PlaylistCollection[T], ABC):
+    """Playlist for APIs where modifications have to be split into mulitple requests.
 
     Subclass this and implement:
-        - _remote_insert_track()  - Add one or multiple track(s)
-        - _remote_delete_track()  - Remove one or multiple track(s)
+        - _remote_insert_track()     - Add one or multiple track(s)
+        - _remote_delete_track()     - Remove one or multiple track(s)
         - _remote_update_metadata()  - Update name/description
-        - _track_key()  - Stable identifier for track equality
+        - _track_key()               - Stable identifier for track equality
 
-    The base class handles diff computation, batching consecutive operations,
+    This base class handles diff computation, batching consecutive operations,
     and rolling back on failure.
+    It also translates the diff between two playlist states into the appropriate
+    sequence of remote API calls.
 
-    Use this when the service API doesn't support bulk playlist operations.
+    Use this when the service API needs multiple calls to set a playlist to
+    a new state (Most services will need this. For example, adding tracks
+    usually has a different endpoint than changing a playlist's description.)
     """
 
-    def _remote_edit(self, before: Snapshot[T], after: Snapshot[T]) -> None:
+    def _remote_commit(self, before: Snapshot[T], after: Snapshot[T]) -> None:
         """Apply minimal remote operations to match after state from before.
 
         Computes the diff between before and after states, then translates

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -147,7 +147,7 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         try:
             yield
             snapshot_after = self.get_snapshot()
-            self._apply_diff(snapshot_before, snapshot_after)
+            self._remote_edit(snapshot_before, snapshot_after)
         except Exception:
             self.tracks = snapshot_before.tracks
             self.name = snapshot_before.name
@@ -192,8 +192,57 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
         """
         raise NotImplementedError()
 
-    def _apply_diff(self, before: Snapshot[T], after: Snapshot[T]) -> None:
-        """Apply minimal remote operations to match after state from before."""
+    # ---------------------- Abstract remote operations ---------------------- #
+
+    @property
+    @abstractmethod
+    def remote_associated(self) -> bool:
+        """Indicate if the playlist is already linked to a remote (online) playlist."""
+        ...
+
+    @abstractmethod
+    def _remote_create(self):
+        """Create the playlist online. Checks are handled in the public version."""
+        ...
+
+    @abstractmethod
+    def _remote_delete(self):
+        """Delete the playlist online."""
+        ...
+
+    @abstractmethod
+    def _remote_edit(self, before: Snapshot[T], after: Snapshot[T]) -> None:
+        """Edit the playlist online."""
+        ...
+
+
+class IncrementalPlaylistCollection(PlaylistCollection[T], ABC):
+    """Playlist editor for services with single-track API operations.
+
+    Some music services only allow adding/removing one track
+    at a time. This class computes the diff between two playlist states and
+    translates it into the appropriate sequence of remote API calls.
+
+    Subclass this and implement:
+        - _remote_insert_track()  - Add one or multiple track(s)
+        - _remote_delete_track()  - Remove one or multiple track(s)
+        - _remote_update_metadata()  - Update name/description
+        - _track_key()  - Stable identifier for track equality
+
+    The base class handles diff computation, batching consecutive operations,
+    and rolling back on failure.
+
+    Use this when the service API doesn't support bulk playlist operations.
+    """
+
+    def _remote_edit(self, before: Snapshot[T], after: Snapshot[T]) -> None:
+        """Apply minimal remote operations to match after state from before.
+
+        Computes the diff between before and after states, then translates
+        each change into the appropriate sequence of remote API calls.
+        Handles metadata updates (name, description) and track operations
+        (insert, delete, move) with automatic rollback on failure.
+        """
         new_name = after.name if before.name != after.name else None
         new_description = (
             after.description if before.description != after.description else None
@@ -228,24 +277,6 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
                         track=step.op.item,
                         tracks_before=step.list_before,
                     )
-
-    # ---------------------- Abstract remote operations ---------------------- #
-
-    @property
-    @abstractmethod
-    def remote_associated(self) -> bool:
-        """Indicate if the playlist is already linked to a remote (online) playlist."""
-        ...
-
-    @abstractmethod
-    def _remote_create(self):
-        """Create the playlist online. Checks are handled in the public version."""
-        ...
-
-    @abstractmethod
-    def _remote_delete(self):
-        """Delete the playlist online."""
-        ...
 
     @abstractmethod
     def _remote_insert_track(

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Self, cast
 
-from plistsync.core.playlist import IncrementalPlaylistCollection, PlaylistInfo
+from plistsync.core.playlist import MultiRequestPlaylistCollection, PlaylistInfo
 from plistsync.logger import log
 
 from .api import PlexApi
@@ -24,7 +24,7 @@ class PlexPlaylistOnlineData:
     tracks_data: Sequence[PlexApiTrackResponse]
 
 
-class PlexPlaylistCollection(IncrementalPlaylistCollection[PlexTrack]):
+class PlexPlaylistCollection(MultiRequestPlaylistCollection[PlexTrack]):
     """
     A collection of all tracks in a Plex playlist.
 

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Self, cast
 
-from plistsync.core.playlist import PlaylistCollection, PlaylistInfo
+from plistsync.core.playlist import IncrementalPlaylistCollection, PlaylistInfo
 from plistsync.logger import log
 
 from .api import PlexApi
@@ -24,7 +24,7 @@ class PlexPlaylistOnlineData:
     tracks_data: Sequence[PlexApiTrackResponse]
 
 
-class PlexPlaylistCollection(PlaylistCollection[PlexTrack]):
+class PlexPlaylistCollection(IncrementalPlaylistCollection[PlexTrack]):
     """
     A collection of all tracks in a Plex playlist.
 

--- a/plistsync/services/spotify/playlist.py
+++ b/plistsync/services/spotify/playlist.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Self
 
-from plistsync.core.playlist import IncrementalPlaylistCollection, PlaylistInfo
+from plistsync.core.playlist import MultiRequestPlaylistCollection, PlaylistInfo
 
 from .api_types import (
     PlaylistTracksBase,
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .library import SpotifyLibraryCollection
 
 
-class SpotifyPlaylistCollection(IncrementalPlaylistCollection[SpotifyPlaylistTrack]):
+class SpotifyPlaylistCollection(MultiRequestPlaylistCollection[SpotifyPlaylistTrack]):
     """A collection representing a spotify playlist."""
 
     library: SpotifyLibraryCollection

--- a/plistsync/services/spotify/playlist.py
+++ b/plistsync/services/spotify/playlist.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Self
 
-from plistsync.core.playlist import PlaylistCollection, PlaylistInfo
+from plistsync.core.playlist import IncrementalPlaylistCollection, PlaylistInfo
 
 from .api_types import (
     PlaylistTracksBase,
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .library import SpotifyLibraryCollection
 
 
-class SpotifyPlaylistCollection(PlaylistCollection[SpotifyPlaylistTrack]):
+class SpotifyPlaylistCollection(IncrementalPlaylistCollection[SpotifyPlaylistTrack]):
     """A collection representing a spotify playlist."""
 
     library: SpotifyLibraryCollection

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from collections.abc import Hashable
 from typing import TYPE_CHECKING, Self, cast
 
-from plistsync.core.playlist import PlaylistCollection, PlaylistInfo, Snapshot
+from plistsync.core.playlist import (
+    IncrementalPlaylistCollection,
+    PlaylistInfo,
+    Snapshot,
+)
 from plistsync.logger import log
 
 from .api import LookupDict
@@ -14,7 +18,7 @@ if TYPE_CHECKING:
     from .library import TidalLibraryCollection
 
 
-class TidalPlaylistCollection(PlaylistCollection[TidalPlaylistTrack]):
+class TidalPlaylistCollection(IncrementalPlaylistCollection[TidalPlaylistTrack]):
     library: TidalLibraryCollection
 
     # When the playlist is associated with an online playlist, we have the response.
@@ -253,12 +257,12 @@ class TidalPlaylistCollection(PlaylistCollection[TidalPlaylistTrack]):
             description=new_description,
         )
 
-    def _apply_diff(
+    def _remote_edit(
         self,
         before: Snapshot[TidalPlaylistTrack],
         after: Snapshot[TidalPlaylistTrack],
     ) -> None:
-        super()._apply_diff(before, after)
+        super()._remote_edit(before, after)
         # After edit we refetch all tracks as their is no other
         # easy way to get the new item ids
         self._refetch_tracks()

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -257,7 +257,7 @@ class TidalPlaylistCollection(MultiRequestPlaylistCollection[TidalPlaylistTrack]
             description=new_description,
         )
 
-    def _remote_edit(
+    def _remote_commit(
         self,
         before: Snapshot[TidalPlaylistTrack],
         after: Snapshot[TidalPlaylistTrack],

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -4,7 +4,7 @@ from collections.abc import Hashable
 from typing import TYPE_CHECKING, Self, cast
 
 from plistsync.core.playlist import (
-    IncrementalPlaylistCollection,
+    MultiRequestPlaylistCollection,
     PlaylistInfo,
     Snapshot,
 )
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .library import TidalLibraryCollection
 
 
-class TidalPlaylistCollection(IncrementalPlaylistCollection[TidalPlaylistTrack]):
+class TidalPlaylistCollection(MultiRequestPlaylistCollection[TidalPlaylistTrack]):
     library: TidalLibraryCollection
 
     # When the playlist is associated with an online playlist, we have the response.
@@ -262,7 +262,7 @@ class TidalPlaylistCollection(IncrementalPlaylistCollection[TidalPlaylistTrack])
         before: Snapshot[TidalPlaylistTrack],
         after: Snapshot[TidalPlaylistTrack],
     ) -> None:
-        super()._remote_edit(before, after)
+        super()._remote_commit(before, after)
         # After edit we refetch all tracks as their is no other
         # easy way to get the new item ids
         self._refetch_tracks()

--- a/plistsync/services/traktor/playlist.py
+++ b/plistsync/services/traktor/playlist.py
@@ -163,17 +163,18 @@ class NMLPlaylistCollection(PlaylistCollection[NMLPlaylistTrack], LocalLookup):
         return int(entries) if entries.isdigit() else 0
 
     # ----------------------------- Remote operations ---------------------------- #
-    # Remote methods are not really needed as we just replace the playlist
-    # node in the library
+    # Traktor does not need many remote operations.
+    # Essentially all we do is to persist changes at the end into the nml file.
 
-    def _remote_edit(
+    def _remote_commit(
         self,
         before: Snapshot[NMLPlaylistTrack],
         after: Snapshot[NMLPlaylistTrack],
     ) -> None:
-        """Wrap apply diff so `edit`."""
+        """Persist current state to nml."""
 
         self._overwrite_track_entries(after.tracks)
+        # TODO: clean up remote_upsert abstraction, want to call public from private?
         self.remote_upsert()
 
     def _remote_create(self):

--- a/plistsync/services/traktor/playlist.py
+++ b/plistsync/services/traktor/playlist.py
@@ -7,7 +7,11 @@ from uuid import uuid4
 from lxml.etree import Element, SubElement, _Element
 
 from plistsync.core.collection import LocalLookup
-from plistsync.core.playlist import PlaylistCollection, PlaylistInfo, Snapshot
+from plistsync.core.playlist import (
+    PlaylistCollection,
+    PlaylistInfo,
+    Snapshot,
+)
 from plistsync.core.track import LocalTrackIDs
 from plistsync.logger import log
 
@@ -162,24 +166,13 @@ class NMLPlaylistCollection(PlaylistCollection[NMLPlaylistTrack], LocalLookup):
     # Remote methods are not really needed as we just replace the playlist
     # node in the library
 
-    def _remote_insert_track(self, *args, **kwargs) -> None:
-        return None
-
-    def _remote_delete_track(self, *args, **kwargs) -> None:
-        return None
-
-    def _remote_update_metadata(self, *args, **kwargs) -> None:
-        return None
-
-    def _apply_diff(
+    def _remote_edit(
         self,
         before: Snapshot[NMLPlaylistTrack],
         after: Snapshot[NMLPlaylistTrack],
     ) -> None:
         """Wrap apply diff so `edit`."""
-        super()._apply_diff(before, after)
-        # Instead of an incremental update we just rewrite everything
-        # here as this is easier and performance isnt really an issue
+
         self._overwrite_track_entries(after.tracks)
         self.remote_upsert()
 
@@ -248,10 +241,6 @@ class NMLPlaylistCollection(PlaylistCollection[NMLPlaylistTrack], LocalLookup):
     def _remote_delete(self):
         """Remove in connected collection."""
         detach(self.root_node)
-
-    @staticmethod
-    def _track_key(track: NMLPlaylistTrack):
-        return track.path
 
     # --------------------------- LocalLookup protocol --------------------------- #
 

--- a/tests/abc.py
+++ b/tests/abc.py
@@ -418,9 +418,9 @@ class MultiRequestPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
     ) -> MultiRequestPlaylistCollection:
         raise NotImplementedError
 
-    # -------------------------------- _remote_edit ------------------------------- #
+    # -------------------------------- _remote_commit ------------------------------- #
 
-    def test_remote_edit_noop_does_nothing(self) -> None:
+    def test_remote_commit_noop_does_nothing(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         t1 = self.create_track(isrc="1")
 
@@ -439,7 +439,7 @@ class MultiRequestPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
         pl._remote_delete_track.assert_not_called()
         pl._remote_move_track.assert_not_called()
 
-    def test_remote_edit_updates_metadata_only(self) -> None:
+    def test_remote_commit_updates_metadata_only(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         t1 = self.create_track(isrc="1")
 
@@ -458,7 +458,7 @@ class MultiRequestPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
         pl._remote_delete_track.assert_not_called()
         pl._remote_move_track.assert_not_called()
 
-    def test_remote_edit_inserts_track(self) -> None:
+    def test_remote_commit_inserts_track(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         t1 = self.create_track(isrc="1")
         t4 = self.create_track(isrc="4")

--- a/tests/abc.py
+++ b/tests/abc.py
@@ -14,7 +14,7 @@ from plistsync.core.collection import (
 )
 from plistsync.core.matching import Matches
 from plistsync.core.playlist import (
-    IncrementalPlaylistCollection,
+    MultiRequestPlaylistCollection,
     PlaylistCollection,
     Snapshot,
 )
@@ -309,7 +309,7 @@ class PlaylistCollectionTestBase(ABC):
         old_name = pl.name
 
         remote_edit_mock = Mock()
-        pl._remote_edit = remote_edit_mock
+        pl._remote_commit = remote_edit_mock
 
         with pl.remote_edit():
             pl.name = f"{old_name} (updated)"
@@ -327,7 +327,7 @@ class PlaylistCollectionTestBase(ABC):
         initial_description = pl.description
         initial_tracks = list(pl.tracks)
 
-        pl._remote_edit = Mock()
+        pl._remote_commit = Mock()
 
         with pytest.raises(ValueError):
             with pl.remote_edit():
@@ -342,7 +342,7 @@ class PlaylistCollectionTestBase(ABC):
         assert pl.tracks == initial_tracks
 
         # since we errored inside the context, diff application should not run
-        pl._remote_edit.assert_not_called()
+        pl._remote_commit.assert_not_called()
 
     # ------------------------------- remote_create ------------------------------ #
 
@@ -409,13 +409,13 @@ class PlaylistCollectionTestBase(ABC):
             mocked.assert_called_once_with()
 
 
-class IncrementalPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
+class MultiRequestPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
     @abstractmethod
     def create_playlist(
         self,
         *,
         remote_associated: bool = True,
-    ) -> IncrementalPlaylistCollection:
+    ) -> MultiRequestPlaylistCollection:
         raise NotImplementedError
 
     # -------------------------------- _remote_edit ------------------------------- #
@@ -432,7 +432,7 @@ class IncrementalPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
         before = Snapshot(name="n", description=None, tracks=[t1])
         after = Snapshot(name="n", description=None, tracks=[t1])
 
-        pl._remote_edit(before, after)
+        pl._remote_commit(before, after)
 
         pl._remote_update_metadata.assert_not_called()
         pl._remote_insert_track.assert_not_called()
@@ -451,7 +451,7 @@ class IncrementalPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
         before = Snapshot(name="old", description="d1", tracks=[t1])
         after = Snapshot(name="new", description="d2", tracks=[t1])
 
-        pl._remote_edit(before, after)
+        pl._remote_commit(before, after)
 
         pl._remote_update_metadata.assert_called_once_with("new", "d2")
         pl._remote_insert_track.assert_not_called()
@@ -474,7 +474,7 @@ class IncrementalPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
         before = Snapshot(name="n", description=None, tracks=[t4])
         after = Snapshot(name="n", description=None, tracks=[t1, t4])
 
-        pl._remote_edit(before, after)
+        pl._remote_commit(before, after)
 
         pl._remote_update_metadata.assert_not_called()
         pl._remote_insert_track.assert_called_once_with(

--- a/tests/abc.py
+++ b/tests/abc.py
@@ -13,7 +13,11 @@ from plistsync.core.collection import (
     TrackStream,
 )
 from plistsync.core.matching import Matches
-from plistsync.core.playlist import PlaylistCollection, Snapshot
+from plistsync.core.playlist import (
+    IncrementalPlaylistCollection,
+    PlaylistCollection,
+    Snapshot,
+)
 
 from unittest.mock import Mock, ANY
 
@@ -300,17 +304,18 @@ class PlaylistCollectionTestBase(ABC):
             with pl.remote_edit():
                 pass
 
-    def test_remote_edit_calls_apply_diff_on_success(self) -> None:
+    def test_remote_edit_calls_remote_edit_on_success(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         old_name = pl.name
 
-        pl._apply_diff = Mock()
+        remote_edit_mock = Mock()
+        pl._remote_edit = remote_edit_mock
 
         with pl.remote_edit():
             pl.name = f"{old_name} (updated)"
 
-        pl._apply_diff.assert_called_once()
-        before, after = pl._apply_diff.call_args.args
+        remote_edit_mock.assert_called_once()
+        before, after = remote_edit_mock.call_args.args
         assert isinstance(before, Snapshot)
         assert isinstance(after, Snapshot)
         assert before.name == old_name
@@ -322,7 +327,7 @@ class PlaylistCollectionTestBase(ABC):
         initial_description = pl.description
         initial_tracks = list(pl.tracks)
 
-        pl._apply_diff = Mock()
+        pl._remote_edit = Mock()
 
         with pytest.raises(ValueError):
             with pl.remote_edit():
@@ -337,7 +342,7 @@ class PlaylistCollectionTestBase(ABC):
         assert pl.tracks == initial_tracks
 
         # since we errored inside the context, diff application should not run
-        pl._apply_diff.assert_not_called()
+        pl._remote_edit.assert_not_called()
 
     # ------------------------------- remote_create ------------------------------ #
 
@@ -403,9 +408,19 @@ class PlaylistCollectionTestBase(ABC):
         else:
             mocked.assert_called_once_with()
 
-    # -------------------------------- _apply_diff ------------------------------- #
 
-    def test_apply_diff_noop_does_nothing(self) -> None:
+class IncrementalPlaylistCollectionTestBase(PlaylistCollectionTestBase, ABC):
+    @abstractmethod
+    def create_playlist(
+        self,
+        *,
+        remote_associated: bool = True,
+    ) -> IncrementalPlaylistCollection:
+        raise NotImplementedError
+
+    # -------------------------------- _remote_edit ------------------------------- #
+
+    def test_remote_edit_noop_does_nothing(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         t1 = self.create_track(isrc="1")
 
@@ -417,14 +432,14 @@ class PlaylistCollectionTestBase(ABC):
         before = Snapshot(name="n", description=None, tracks=[t1])
         after = Snapshot(name="n", description=None, tracks=[t1])
 
-        pl._apply_diff(before, after)
+        pl._remote_edit(before, after)
 
         pl._remote_update_metadata.assert_not_called()
         pl._remote_insert_track.assert_not_called()
         pl._remote_delete_track.assert_not_called()
         pl._remote_move_track.assert_not_called()
 
-    def test_apply_diff_updates_metadata_only(self) -> None:
+    def test_remote_edit_updates_metadata_only(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         t1 = self.create_track(isrc="1")
 
@@ -436,14 +451,14 @@ class PlaylistCollectionTestBase(ABC):
         before = Snapshot(name="old", description="d1", tracks=[t1])
         after = Snapshot(name="new", description="d2", tracks=[t1])
 
-        pl._apply_diff(before, after)
+        pl._remote_edit(before, after)
 
         pl._remote_update_metadata.assert_called_once_with("new", "d2")
         pl._remote_insert_track.assert_not_called()
         pl._remote_delete_track.assert_not_called()
         pl._remote_move_track.assert_not_called()
 
-    def test_apply_diff_inserts_track(self) -> None:
+    def test_remote_edit_inserts_track(self) -> None:
         pl = self.create_playlist(remote_associated=True)
         t1 = self.create_track(isrc="1")
         t4 = self.create_track(isrc="4")
@@ -459,7 +474,7 @@ class PlaylistCollectionTestBase(ABC):
         before = Snapshot(name="n", description=None, tracks=[t4])
         after = Snapshot(name="n", description=None, tracks=[t1, t4])
 
-        pl._apply_diff(before, after)
+        pl._remote_edit(before, after)
 
         pl._remote_update_metadata.assert_not_called()
         pl._remote_insert_track.assert_called_once_with(

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -1,7 +1,7 @@
 import random
 from typing import Any
 from plistsync.core.playlist import (
-    IncrementalPlaylistCollection,
+    MultiRequestPlaylistCollection,
     PlaylistCollection,
     PlaylistInfo,
     Snapshot,
@@ -35,8 +35,8 @@ class MockPlaylist(PlaylistCollection[MockTrack]):
     def remote_associated(self):
         return self._remote_associated
 
-    def _remote_edit(self, before: Snapshot[MockTrack], after: Snapshot[MockTrack]):
-        self.log.append(("edit",))
+    def _remote_commit(self, before: Snapshot[MockTrack], after: Snapshot[MockTrack]):
+        self.log.append(("remote_commit",))
 
     def _remote_create(self):
         self.log.append(("remote_create",))
@@ -47,7 +47,7 @@ class MockPlaylist(PlaylistCollection[MockTrack]):
         self._remote_associated = False
 
 
-class MockPlaylistIncremental(IncrementalPlaylistCollection[MockTrack], MockPlaylist):
+class MockPlaylistMultiRequest(MultiRequestPlaylistCollection[MockTrack], MockPlaylist):
     """Mock IncrementalPlaylistCollection implementation for testing."""
 
     def _remote_delete_track(

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -1,8 +1,15 @@
+import random
 from typing import Any
-from plistsync.core.playlist import PlaylistCollection, PlaylistInfo
+from plistsync.core.playlist import (
+    IncrementalPlaylistCollection,
+    PlaylistCollection,
+    PlaylistInfo,
+    Snapshot,
+)
+from tests.core.mock_track import MockTrack
 
 
-class MockPlaylist(PlaylistCollection):
+class MockPlaylist(PlaylistCollection[MockTrack]):
     """Mock PlaylistCollection implementation for testing."""
 
     def __init__(
@@ -23,6 +30,25 @@ class MockPlaylist(PlaylistCollection):
     @info.setter
     def info(self, value: PlaylistInfo):
         self._info = value
+
+    @property
+    def remote_associated(self):
+        return self._remote_associated
+
+    def _remote_edit(self, before: Snapshot[MockTrack], after: Snapshot[MockTrack]):
+        self.log.append(("edit",))
+
+    def _remote_create(self):
+        self.log.append(("remote_create",))
+        self._remote_associated = True
+
+    def _remote_delete(self):
+        self.log.append(("remote_delete",))
+        self._remote_associated = False
+
+
+class MockPlaylistIncremental(IncrementalPlaylistCollection[MockTrack], MockPlaylist):
+    """Mock IncrementalPlaylistCollection implementation for testing."""
 
     def _remote_delete_track(
         self,
@@ -53,18 +79,6 @@ class MockPlaylist(PlaylistCollection):
     ):
         self.log.append(("update_meta", new_name, new_description))
 
-    def _remote_create(self):
-        self.log.append(("remote_create",))
-        self._remote_associated = True
-
-    def _remote_delete(self):
-        self.log.append(("remote_delete",))
-        self._remote_associated = False
-
-    @property
-    def remote_associated(self):
-        return self._remote_associated
-
     @staticmethod
     def _track_key(track) -> str:
-        return track.global_ids["isrc"]  # Fixed to match test expectations
+        return track.global_ids.get("isrc", str(random.randbytes(10)))

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -3,9 +3,9 @@ import pytest
 
 from plistsync.core.playlist import Snapshot
 from plistsync.core.track import GlobalTrackIDs
-from tests.abc import PlaylistCollectionTestBase
+from tests.abc import IncrementalPlaylistCollectionTestBase, PlaylistCollectionTestBase
 from .mock_track import MockTrack
-from .mock_playlist import MockPlaylist
+from .mock_playlist import MockPlaylist, MockPlaylistIncremental
 
 
 @pytest.fixture
@@ -18,6 +18,22 @@ def make_playlist() -> Callable[..., MockPlaylist]:
     ) -> MockPlaylist:
         tracks = [MockTrack(global_ids=gid) for gid in (ids or [])]
         return MockPlaylist(name, tracks, remote_associated=remote_associated)
+
+    return _make
+
+
+@pytest.fixture
+def make_incremental_playlist() -> Callable[..., MockPlaylist]:
+    def _make(
+        *,
+        name: str = "foo",
+        ids: list[GlobalTrackIDs] | None = None,
+        remote_associated: bool = True,
+    ) -> MockPlaylist:
+        tracks = [MockTrack(global_ids=gid) for gid in (ids or [])]
+        return MockPlaylistIncremental(
+            name, tracks, remote_associated=remote_associated
+        )
 
     return _make
 
@@ -92,12 +108,12 @@ class TestPlaylistCollection:
     )
     def test_edit_tracks(
         self,
-        make_playlist,
+        make_incremental_playlist,
         ids_before,
         ids_after,
         expected_log,
     ) -> None:
-        pl = make_playlist(ids=ids_before)
+        pl = make_incremental_playlist(ids=ids_before)
         with pl.remote_edit():
             pl._tracks = [MockTrack(global_ids=ta) for ta in ids_after]
 
@@ -105,16 +121,16 @@ class TestPlaylistCollection:
         # Check log
         assert [(op, idx, t.global_ids) for (op, idx, t) in pl.log] == expected_log
 
-    def test_edit_metadata(self, make_playlist) -> None:
-        pl = make_playlist()
+    def test_edit_metadata(self, make_incremental_playlist) -> None:
+        pl = make_incremental_playlist()
 
         with pl.remote_edit():
             pl.name = "bar"
 
         assert pl.name == "bar"
 
-    def test_edit_rollback(self, make_playlist) -> None:
-        pl = make_playlist()
+    def test_edit_rollback(self, make_incremental_playlist) -> None:
+        pl = make_incremental_playlist()
 
         with pytest.raises(ValueError):
             with pl.remote_edit():
@@ -187,3 +203,14 @@ class TestMockPlaylistCollection(PlaylistCollectionTestBase):
 
         with pytest.raises(ValueError, match="has no name"):
             pl.name
+
+
+class TestMockPlaylistIncrementalCollection(IncrementalPlaylistCollectionTestBase):
+    def create_playlist(
+        self, *, remote_associated: bool = True
+    ) -> MockPlaylistIncremental:
+        return MockPlaylistIncremental(
+            "pl",
+            None,
+            remote_associated=remote_associated,
+        )

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -3,9 +3,9 @@ import pytest
 
 from plistsync.core.playlist import Snapshot
 from plistsync.core.track import GlobalTrackIDs
-from tests.abc import IncrementalPlaylistCollectionTestBase, PlaylistCollectionTestBase
+from tests.abc import MultiRequestPlaylistCollectionTestBase, PlaylistCollectionTestBase
 from .mock_track import MockTrack
-from .mock_playlist import MockPlaylist, MockPlaylistIncremental
+from .mock_playlist import MockPlaylist, MockPlaylistMultiRequest
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def make_playlist() -> Callable[..., MockPlaylist]:
 
 
 @pytest.fixture
-def make_incremental_playlist() -> Callable[..., MockPlaylist]:
+def make_multi_request_playlist() -> Callable[..., MockPlaylist]:
     def _make(
         *,
         name: str = "foo",
@@ -31,7 +31,7 @@ def make_incremental_playlist() -> Callable[..., MockPlaylist]:
         remote_associated: bool = True,
     ) -> MockPlaylist:
         tracks = [MockTrack(global_ids=gid) for gid in (ids or [])]
-        return MockPlaylistIncremental(
+        return MockPlaylistMultiRequest(
             name, tracks, remote_associated=remote_associated
         )
 
@@ -108,12 +108,12 @@ class TestPlaylistCollection:
     )
     def test_edit_tracks(
         self,
-        make_incremental_playlist,
+        make_multi_request_playlist,
         ids_before,
         ids_after,
         expected_log,
     ) -> None:
-        pl = make_incremental_playlist(ids=ids_before)
+        pl = make_multi_request_playlist(ids=ids_before)
         with pl.remote_edit():
             pl._tracks = [MockTrack(global_ids=ta) for ta in ids_after]
 
@@ -121,16 +121,16 @@ class TestPlaylistCollection:
         # Check log
         assert [(op, idx, t.global_ids) for (op, idx, t) in pl.log] == expected_log
 
-    def test_edit_metadata(self, make_incremental_playlist) -> None:
-        pl = make_incremental_playlist()
+    def test_edit_metadata(self, make_multi_request_playlist) -> None:
+        pl = make_multi_request_playlist()
 
         with pl.remote_edit():
             pl.name = "bar"
 
         assert pl.name == "bar"
 
-    def test_edit_rollback(self, make_incremental_playlist) -> None:
-        pl = make_incremental_playlist()
+    def test_edit_rollback(self, make_multi_request_playlist) -> None:
+        pl = make_multi_request_playlist()
 
         with pytest.raises(ValueError):
             with pl.remote_edit():
@@ -205,11 +205,11 @@ class TestMockPlaylistCollection(PlaylistCollectionTestBase):
             pl.name
 
 
-class TestMockPlaylistIncrementalCollection(IncrementalPlaylistCollectionTestBase):
+class TestMockPlaylistIncrementalCollection(MultiRequestPlaylistCollectionTestBase):
     def create_playlist(
         self, *, remote_associated: bool = True
-    ) -> MockPlaylistIncremental:
-        return MockPlaylistIncremental(
+    ) -> MockPlaylistMultiRequest:
+        return MockPlaylistMultiRequest(
             "pl",
             None,
             remote_associated=remote_associated,


### PR DESCRIPTION
Splits the `_apply_diff` method and related abstract methods into a dedicated
class (`IncrementalPlaylistCollection`). This allows services with replace
APIs to use a simpler base class without the overhead of single-track operations.

TODO:
- [x] Finalize abstraction and naming
- [x] Migrate existing services to the new structure

Closes #64
