### PR TITLE
Playlist init: Make `library` optional + Define Library Attachment Strategy

### DIFF
--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -20,7 +20,7 @@ the required methods.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Hashable
+from collections.abc import Hashable, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
@@ -79,11 +79,33 @@ class PlaylistCollection(Generic[T], Collection[T], TrackStream[T], ABC):
 
     """
 
+    @abstractmethod
+    def __init__(
+        self,
+        title: str,
+        description: str | None = None,
+        tracks: Sequence[Track] | None = None,
+    ) -> None:
+        """Initialize the playlist.
+
+        This should create a local object that is **not** linked
+        to the service (yet).
+
+        Parameters
+        ----------
+        title : str
+            The name of the playlist.
+        description : str, optional
+            An optional description of the playlist.
+        tracks : Sequence[Track], optional
+            Initial list of tracks to include in the playlist.
+        """
+        ...
+
     @property
     @abstractmethod
     def info(self) -> PlaylistInfo:
-        """
-        Get this playlist's information.
+        """Get this playlist's information.
 
         Subclasses need return a reference, so that the setters for name
         etc. that are defined here, write back.


### PR DESCRIPTION
Playlist constructors currently **require** a `library` parameter:

```python
    def __init__(
        self,
        library: AnyLibrary,  # <-- Required, even when not needed
        name: str,
        description: str | None = None,
        tracks: list[AnyTrack] | None = None,
    ):
```

This feels awkward because we're forced to provide a library even when just creating playlists locally, there is no guarantee the library is actually connected or valid at that point, and the base class doesn't enforce a consistent signature (no abstract `__init__`). Overall this introduces an implicit dependency on a live service too early imo.

**Proposal:**

In migration or transformation scenarios, we often construct playlists, transform or filter them, and only then decide to persist them. Requiring a library upfront forces us to bind to a service prematurely, which doesn't match this workflow. Instead, we could allow constructing playlists without a library and attach it later when needed.

```python
def __init__(
    self,
    name: str,
    description: str | None = None,
    tracks: list[AnyTrack] | None = None,
):
```

The library would then be attached explicitly via playlist.attach_library(lib) or playlist.library = lib. This allows creating playlists locally and attaching them retroactively once a concrete backend is available. This should make it easier to create multi-user and multi-library workflows. Also makes working with the library more intuitive imo.
