### PR TITLE
Remove config dependency from api layers

### DIFF
--- a/plistsync/services/plex/api.py
+++ b/plistsync/services/plex/api.py
@@ -7,7 +7,6 @@ happens on in the playlist.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import cache, cached_property
@@ -17,8 +16,8 @@ from urllib.parse import quote
 
 import requests
 
-from plistsync.config import Config, ConfigurationError, PlexConfig
 from plistsync.logger import log
+from plistsync.utils.auth.bearer_token import InvalidTokenError, Token, TokenSession
 
 from .api_types import (
     PlexApiConnection,
@@ -31,79 +30,130 @@ from .api_types import (
 )
 
 
-def _read_token(path: Path) -> str:
-    if not path.exists():
-        raise ConfigurationError(
-            f"Plex token file not found at {path}! "
-            "Please run `plistsync plex auth` to authenticate."
-        )
-    with open(path) as f:
-        data = json.load(f)
-    token = data.get("X-Plex-Token")
-    if token is None:
-        raise ConfigurationError(
-            "Plex token not found! Please run `plistsync plex auth` to authenticate."
-        )
-    return token
+class PlexToken(Token):
+    x_plex_token: str
+    validated: bool
+
+    def __init__(self, x_plex_token: str, file_path: Path | None):
+        super().__init__(file_path)
+        self.x_plex_token = x_plex_token
+        self.validated = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"X-Plex-Token": self.x_plex_token}
+
+    @classmethod
+    def from_dict(cls, token_dict):
+        return cls(token_dict["X-Plex-Token"], None)
+
+    def __call__(self, request: requests.PreparedRequest) -> requests.PreparedRequest:
+        """Prepare the request to use the authentication."""
+        request.headers["X-Plex-Token"] = self.x_plex_token
+        return request
 
 
-class PlexApiSession(requests.Session):
+class PlexApiSession(TokenSession[PlexToken]):
     """A requests Session configured for Plex API requests.
 
     Automatically attaches the Plex auth token and refreshes
     it as needed. Use for making multiple requests to the Plex API.
     """
 
-    token_valid: bool
     server_url: str
 
     def __init__(
         self,
         product: str,
-        client_identifier: str,
-        token: str,
+        client_id: str,
         server_url: str,
+        token: PlexToken,
     ) -> None:
         """Initialize the PlexApiSession."""
-        super().__init__()
-        self.token_valid = False
+        super().__init__(token)
         self.headers["Accept"] = "application/json"
-        self.headers["X-Plex-Client-Identifier"] = client_identifier
+        self.headers["X-Plex-Client-Identifier"] = client_id
         self.headers["X-Plex-Product"] = product
-        self.headers["X-Plex-Token"] = token
         self.server_url = server_url
 
-    def _validate_token(self) -> None:
-        """Validate the Plex token by making a test request.
+    @classmethod
+    def from_config(cls):
+        from plistsync.config import Config, ConfigurationError
 
-        According to Plex API docs, one should use the /api/v2/user endpoint
-        to validate tokens.
+        plex_config = Config().plex
+
+        def _resolve_server_name(server_name: str):
+            # we need a temporary session for plex.tv, but later want one that uses the
+            # local server name
+            log.info(
+                f"Looking up server ip for '{server_name}', this might take a bit. "
+                "To speed this up, use a server_url in stead of server_name."
+            )
+            temp_session = cls(
+                plex_config.app_name,
+                plex_config.client_identifier,
+                "https://plex.tv",
+                PlexToken.from_file(plex_config.token_path),
+            )
+
+            conns = PlexApi.get_server_connections_for_name(temp_session, server_name)
+            return PlexApi.get_valid_connection(temp_session, conns).get("uri", "")
+
+        # priority of server url sources:
+        server_url: str
+        if plex_config.server_url:
+            server_url = plex_config.server_url
+        elif plex_config.server_name:
+            server_url = _resolve_server_name(plex_config.server_name)
+        else:
+            raise ConfigurationError(
+                "Specify either plex.server_url or plex.server_name."
+            )
+
+        return cls(
+            plex_config.app_name,
+            plex_config.client_identifier,
+            server_url,
+            PlexToken.from_file(plex_config.token_path),
+        )
+
+    def _validate_token(self) -> None:
+        """Validate token.
+
+        More of a validate here as it is not possible
+        to refresh with the current flow.
         """
         try:
             response = super().request("GET", f"{self.server_url}/api/v2/user")
             if response.status_code == 401:
-                raise ConfigurationError(
-                    "Plex token not valid anymore! "
-                    "Run `plistsync plex auth` to refresh it."
-                )
-            self.token_valid = True
+                raise InvalidTokenError(self.token)
+            self.token.validated = True
         except requests.exceptions.RequestException as e:
-            raise ConfigurationError(
+            raise ValueError(
                 f"Plex token validation failed due to network error: {str(e)}"
             ) from e
 
-    def request(self, *args, **kwargs) -> requests.Response:
-        """Override request to add Plex auth token and headers."""
-        # On the first request, check that the token is valid
-        if not self.token_valid:
+    def request(
+        self, method: str | bytes, url: str | bytes, *args, **kwargs
+    ) -> requests.Response:
+        """Request with Plex auth token and headers."""
+        if not self.token.validated:
             self._validate_token()
 
-        try:
-            return super().request(*args, **kwargs)
-        except requests.exceptions.RequestException as e:
-            raise ConfigurationError(
-                f"Plex API request failed due to network error: {str(e)}"
-            ) from e
+        log.debug("Request: %s", url)
+        res = super().request(
+            method,
+            url,
+            *args,
+            **kwargs,
+        )
+        res.raise_for_status()
+        return res
+
+    def _refresh_token(self) -> None:
+        return
+
+    def _handle_rate_limit(self, *a, **k) -> None:
+        return
 
 
 class PlexApi:
@@ -121,50 +171,12 @@ class PlexApi:
     track: TrackApi
     converts: ConvertsApi
 
-    def __init__(
-        self,
-        server_url: str | None = None,
-        server_name: str | None = None,
-    ) -> None:
-        self.plex_config: PlexConfig = Config().plex
-
-        def _resolve_server_name(server_name):
-            # we need a temporary session for plex.tv, but later want one that uses the
-            # local server name
-            log.info(
-                f"Looking up server ip for '{server_name}', this might take a bit. "
-                "To speed this up, use a server_url in stead of server_name."
-            )
-            temp_session = PlexApiSession(
-                self.plex_config.app_name,
-                self.plex_config.client_identifier,
-                _read_token(self.plex_config.token_path),
-                "https://plex.tv",
-            )
-            conns = self.get_server_connections_for_name(temp_session, server_name)
-            return self.get_valid_connection(temp_session, conns).get("uri", "")
-
-        # priority of server url sources:
-        if server_url:
-            pass
-        elif server_name:
-            server_url = _resolve_server_name(server_name)
-        elif self.plex_config.server_url:
-            server_url = self.plex_config.server_url
-        elif self.plex_config.server_name:
-            server_url = _resolve_server_name(self.plex_config.server_name)
-        else:
-            raise ValueError(
-                "Specify either server_url or server_name (in your config or as kwarg)."
-            )
+    def __init__(self, session: PlexApiSession | None = None) -> None:
+        if session is None:
+            session = PlexApiSession.from_config()
 
         # create permanent session for remaining requests
-        self.session = PlexApiSession(
-            self.plex_config.app_name,
-            self.plex_config.client_identifier,
-            _read_token(self.plex_config.token_path),
-            server_url,
-        )
+        self.session = session
         self.playlist = PlaylistApi(self)
         self.track = TrackApi(self.session)
         self.converts = ConvertsApi(self.session, self)

--- a/plistsync/services/plex/library.py
+++ b/plistsync/services/plex/library.py
@@ -40,8 +40,6 @@ class PlexLibrarySectionCollection(
     def __init__(
         self,
         section_name_or_id: str | int,
-        server_url: str | None = None,
-        server_name: str | None = None,
     ):
         """Initialize the PlexLibraryCollection from plex given a section id.
 
@@ -49,10 +47,8 @@ class PlexLibrarySectionCollection(
         ----------
         section_name_or_id : str | int
             The Name or ID of the Plex library section to fetch.
-        server_url : str, optional
-            The server for this collection. If not specified, loaded from config.
         """
-        self.api = PlexApi(server_url=server_url, server_name=server_name)
+        self.api = PlexApi()
         self.id = self.api.converts.section_name_to_id(section_name_or_id)
 
     def preload(self, force_reload=False) -> None:

--- a/plistsync/services/spotify/api.py
+++ b/plistsync/services/spotify/api.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
 from collections import Counter
+from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 import requests
 from requests.structures import CaseInsensitiveDict
-from requests_oauth2client import ExpiredAccessToken
 
-from plistsync.config import Config
 from plistsync.logger import log
 from plistsync.utils import chunk_list
 from plistsync.utils.auth.bearer_token import (
     BearerToken,
+    BearerTokenSession,
     InvalidTokenError,
-    get_bearer_token,
 )
 
 from .api_types import (
@@ -31,20 +30,41 @@ if TYPE_CHECKING:
     )
 
 
-class SpotifyApiSession(requests.Session):
+class SpotifyApiSession(BearerTokenSession):
     """A requests Session configured for Spotify.
 
     Automatically attaches the auth token and refreshes
     it as needed. Use for making multiple requests to the API.
     """
 
-    token: BearerToken
+    # Used in BearerTokenSession
+    status_codes_expired: ClassVar[list[int]] = [401]
+    status_codes_rate_limit: ClassVar[list[int]] = [429]
+
     server_url: ClassVar[str] = "https://api.spotify.com/v1"
 
-    def __init__(self):
-        super().__init__()
+    client_id: str
+
+    def __init__(
+        self,
+        client_id: str,
+        token: BearerToken | None = None,
+        token_path: Path | None = None,
+    ):
+        super().__init__(token, token_path)
+        self.client_id = client_id
         self.headers["Accept"] = "application/json"
-        self.token = get_bearer_token("spotify")
+
+    @classmethod
+    def from_config(cls):
+        from plistsync.config import Config
+
+        config = Config()
+        return cls(
+            config.spotify.client_id,
+            None,
+            token_path=config.get_dir() / "spotify_token.json",
+        )
 
     def _refresh_token(self) -> None:
         """Validate the spotify token by making a test request.
@@ -53,12 +73,11 @@ class SpotifyApiSession(requests.Session):
         to validate tokens.
         """
         log.debug("Refreshing expired Spotify token...")
-        spotify_config = Config().spotify
         res = requests.post(
             "https://accounts.spotify.com/api/token",
             data={
                 "grant_type": "refresh_token",
-                "client_id": spotify_config.client_id,
+                "client_id": self.client_id,
                 "refresh_token": self.token.as_dict()["refresh_token"],
             },
         )
@@ -70,7 +89,6 @@ class SpotifyApiSession(requests.Session):
 
         token_data = res.json()
         self.token.update(token_data)
-        self.token.save(Config.get_dir() / "spotify_token.json")
 
     def _handle_rate_limit(self, headers: CaseInsensitiveDict) -> None:
         remaining = int(headers.get("Retry-After", 0))
@@ -90,48 +108,19 @@ class SpotifyApiSession(requests.Session):
 
         Slightly different from the normal request, this will raise the status code!
         """
-        if self.token.is_expired:
-            self._refresh_token()
-
         # Prepend spotify API base URL if not a full URL
         if isinstance(url, str) and not url.startswith("http"):
             url = self.server_url + url
 
-        # Always use our Spotify token for authentication
-        kwargs["auth"] = self.token
-
-        # Calling requests again can in theory
-        # create a infinite recursion but
-        # should not happen in practice (fingers crossed)
-        # we can add some max retry logic if this ever
-        # is an issue
-        try:
-            res = super().request(
-                method,
-                url,
-                *args,
-                **kwargs,
-            )
-            res.raise_for_status()
-            return res
-        except ExpiredAccessToken:
-            # Avoid leaking via ExpiredAccessToken by extra try with raise from None
-            try:
-                self._refresh_token()
-                return self.request(method, url, *args, **kwargs)
-            except Exception as e:
-                raise e from None
-        except requests.HTTPError as e:
-            # Handle rate limiting
-            if e.response.status_code == 429:
-                self._handle_rate_limit(e.response.headers)
-                return self.request(method, url, *args, **kwargs)
-
-            # Handle token expiration
-            if e.response.status_code == 401:
-                self._refresh_token()
-                return self.request(method, url, *args, **kwargs)
-            raise e
+        log.debug("Request: %s", url)
+        res = super().request(
+            method,
+            url,
+            *args,
+            **kwargs,
+        )
+        res.raise_for_status()
+        return res
 
 
 class SpotifyApi:
@@ -143,8 +132,11 @@ class SpotifyApi:
     track: TrackApi
     user: UserApi
 
-    def __init__(self):
-        self.session = SpotifyApiSession()
+    def __init__(self, session: SpotifyApiSession | None = None):
+        if session is None:
+            session = SpotifyApiSession.from_config()
+
+        self.session = session
         self.playlist = PlaylistApi(self.session, self)
         self.user = UserApi(self.session, self)
         self.track = TrackApi(self.session)

--- a/plistsync/services/spotify/api.py
+++ b/plistsync/services/spotify/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import Counter
-from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
@@ -11,9 +10,9 @@ from requests.structures import CaseInsensitiveDict
 from plistsync.logger import log
 from plistsync.utils import chunk_list
 from plistsync.utils.auth.bearer_token import (
-    BearerToken,
-    BearerTokenSession,
     InvalidTokenError,
+    Oauth2Token,
+    TokenSession,
 )
 
 from .api_types import (
@@ -30,7 +29,7 @@ if TYPE_CHECKING:
     )
 
 
-class SpotifyApiSession(BearerTokenSession):
+class SpotifyApiSession(TokenSession[Oauth2Token]):
     """A requests Session configured for Spotify.
 
     Automatically attaches the auth token and refreshes
@@ -48,10 +47,9 @@ class SpotifyApiSession(BearerTokenSession):
     def __init__(
         self,
         client_id: str,
-        token: BearerToken | None = None,
-        token_path: Path | None = None,
+        token: Oauth2Token,
     ):
-        super().__init__(token, token_path)
+        super().__init__(token)
         self.client_id = client_id
         self.headers["Accept"] = "application/json"
 
@@ -62,8 +60,9 @@ class SpotifyApiSession(BearerTokenSession):
         config = Config()
         return cls(
             config.spotify.client_id,
-            None,
-            token_path=config.get_dir() / "spotify_token.json",
+            Oauth2Token.from_file(
+                config.get_dir() / "spotify_token.json",
+            ),
         )
 
     def _refresh_token(self) -> None:

--- a/plistsync/services/spotify/authenticate.py
+++ b/plistsync/services/spotify/authenticate.py
@@ -13,7 +13,7 @@ from plistsync.config import Config
 from plistsync.errors import AuthenticationError
 from plistsync.logger import log
 from plistsync.utils import build_url
-from plistsync.utils.auth.bearer_token import BearerToken
+from plistsync.utils.auth.bearer_token import Oauth2Token
 
 SCOPES = " ".join(
     [
@@ -114,7 +114,7 @@ def auth(
     token_data = response.json()
 
     # Create BearerToken instance and save it
-    token = BearerToken.from_dict(token_data)
-    f_path = Config.get_dir() / "spotify_token.json"
-    token.save(f_path)
-    typer.echo(f"Authentication successful! Spotify token saved to {f_path}.")
+    token = Oauth2Token.from_dict(token_data)
+    token.file_path = Config.get_dir() / "spotify_token.json"
+    token.save()
+    typer.echo(f"Authentication successful! Spotify token saved to {token.file_path}.")

--- a/plistsync/services/tidal/api.py
+++ b/plistsync/services/tidal/api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from time import sleep
 from typing import Any, ClassVar, Literal, cast
 
@@ -10,9 +9,9 @@ from requests.structures import CaseInsensitiveDict
 from plistsync.logger import log
 from plistsync.utils import chunk_list
 from plistsync.utils.auth.bearer_token import (
-    BearerToken,
-    BearerTokenSession,
     InvalidTokenError,
+    Oauth2Token,
+    TokenSession,
 )
 
 from .api_types import (
@@ -44,7 +43,7 @@ LookupDict = dict[tuple[str, str], T_Included]
 MAX_FILTER_SIZE = 20  # Tidal limits 20 elements per request
 
 
-class TidalApiSession(BearerTokenSession):
+class TidalApiSession(TokenSession):
     """A request Session configured for Tidal.
 
     Automatically attaches the auth token and refreshes
@@ -62,10 +61,9 @@ class TidalApiSession(BearerTokenSession):
     def __init__(
         self,
         client_id: str,
-        token: BearerToken | None = None,
-        token_path: Path | None = None,
+        token: Oauth2Token,
     ):
-        super().__init__(token, token_path)
+        super().__init__(token)
         self.client_id = client_id
 
     @classmethod
@@ -76,8 +74,9 @@ class TidalApiSession(BearerTokenSession):
         config = Config()
         return cls(
             config.tidal.client_id,
-            None,
-            token_path=config.get_dir() / "tidal_token.json",
+            Oauth2Token.from_file(
+                config.get_dir() / "tidal_token.json",
+            ),
         )
 
     def _refresh_token(self) -> None:

--- a/plistsync/services/tidal/api.py
+++ b/plistsync/services/tidal/api.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
 from time import sleep
 from typing import Any, ClassVar, Literal, cast
 
 import requests
 from requests.structures import CaseInsensitiveDict
-from requests_oauth2client import ExpiredAccessToken
 
-from plistsync.config import Config
 from plistsync.logger import log
 from plistsync.utils import chunk_list
 from plistsync.utils.auth.bearer_token import (
     BearerToken,
+    BearerTokenSession,
     InvalidTokenError,
-    get_bearer_token,
 )
 
 from .api_types import (
@@ -45,19 +44,41 @@ LookupDict = dict[tuple[str, str], T_Included]
 MAX_FILTER_SIZE = 20  # Tidal limits 20 elements per request
 
 
-class TidalApiSession(requests.Session):
+class TidalApiSession(BearerTokenSession):
     """A request Session configured for Tidal.
 
     Automatically attaches the auth token and refreshes
     it as needed. Use for making multiple requests to the API.
     """
 
-    token: BearerToken
+    # Used in BearerTokenSession
+    status_codes_expired: ClassVar[list[int]] = [401]
+    status_codes_rate_limit: ClassVar[list[int]] = [429]
+
     server_url: ClassVar[str] = "https://openapi.tidal.com/v2"
 
-    def __init__(self):
-        super().__init__()
-        self.token = get_bearer_token("tidal")
+    client_id: str
+
+    def __init__(
+        self,
+        client_id: str,
+        token: BearerToken | None = None,
+        token_path: Path | None = None,
+    ):
+        super().__init__(token, token_path)
+        self.client_id = client_id
+
+    @classmethod
+    def from_config(cls):
+        """Initialize a tidal api from configutation file."""
+        from plistsync.config import Config
+
+        config = Config()
+        return cls(
+            config.tidal.client_id,
+            None,
+            token_path=config.get_dir() / "tidal_token.json",
+        )
 
     def _refresh_token(self) -> None:
         """Refresh the Tidal token.
@@ -66,13 +87,13 @@ class TidalApiSession(requests.Session):
         It will update the token in place.
         """
         log.debug("Refreshing expired Tidal token...")
-        tidal_config = Config().tidal
-        res = super().request(
+        res = requests.Session.request(
+            self,
             "POST",
             "https://auth.tidal.com/v1/oauth2/token",
             data={
                 "grant_type": "refresh_token",
-                "client_id": tidal_config.client_id,
+                "client_id": self.client_id,
                 "refresh_token": self.token.as_dict()["refresh_token"],
             },
         )
@@ -84,7 +105,6 @@ class TidalApiSession(requests.Session):
 
         token_data = res.json()
         self.token.update(token_data)
-        self.token.save(Config.get_dir() / "tidal_token.json")
 
     def _handle_rate_limit(self, headers: CaseInsensitiveDict) -> None:
         remaining = int(headers.get("Retry-After", 0))
@@ -104,49 +124,19 @@ class TidalApiSession(requests.Session):
 
         Slightly different from the normal request, this will raise the status code!
         """
-        if self.token.is_expired:
-            self._refresh_token()
-
         # Prepend API base URL if not a full URL
         if isinstance(url, str) and not url.startswith("http"):
             url = self.server_url + url
 
-        # Always use our Spotify token for authentication
-        kwargs["auth"] = self.token
-
-        # Calling requests again can in theory
-        # create a infinite recursion but
-        # should not happen in practice (fingers crossed)
-        # we can add some max retry logic if this ever
-        # is an issue
-        try:
-            log.debug("Request: %s", url)
-            res = super().request(
-                method,
-                url,
-                *args,
-                **kwargs,
-            )
-            res.raise_for_status()
-            return res
-        except ExpiredAccessToken:
-            # Avoid leaking via ExpiredAccessToken by extra try with raise from None
-            try:
-                self._refresh_token()
-                return self.request(method, url, *args, **kwargs)
-            except Exception as e:
-                raise e from None
-        except requests.HTTPError as e:
-            # Handle rate limiting
-            if e.response.status_code == 429:
-                self._handle_rate_limit(e.response.headers)
-                return self.request(method, url, *args, **kwargs)
-
-            # Handle token expiration
-            if e.response.status_code == 401:
-                self._refresh_token()
-                return self.request(method, url, *args, **kwargs)
-            raise e
+        log.debug("Request: %s", url)
+        res = super().request(
+            method,
+            url,
+            *args,
+            **kwargs,
+        )
+        res.raise_for_status()
+        return res
 
     def get_paginated(
         self,
@@ -299,8 +289,11 @@ class TidalApi:
     playlist: TidalPlaylistApi
     user: TidalUserApi
 
-    def __init__(self):
-        self.session = TidalApiSession()
+    def __init__(self, session: TidalApiSession | None = None):
+        if session is None:
+            session = TidalApiSession.from_config()
+
+        self.session = session
         self.tracks = TidalTrackApi(self.session)
         self.playlist = TidalPlaylistApi(self.session)
         self.user = TidalUserApi(self.session)

--- a/plistsync/services/tidal/authenticate.py
+++ b/plistsync/services/tidal/authenticate.py
@@ -13,7 +13,7 @@ from plistsync.config import Config
 from plistsync.errors import AuthenticationError
 from plistsync.logger import log
 from plistsync.utils import build_url
-from plistsync.utils.auth.bearer_token import BearerToken
+from plistsync.utils.auth.bearer_token import Oauth2Token
 
 SCOPES = " ".join(
     [
@@ -115,7 +115,7 @@ def auth(
     token_data = response.json()
 
     # Create BearerToken instance and save it
-    token = BearerToken.from_dict(token_data)
-    f_path = Config.get_dir() / "tidal_token.json"
-    token.save(f_path)
-    typer.echo(f"Authentication successful! Tidal token saved to {f_path}.")
+    token = Oauth2Token.from_dict(token_data)
+    token.file_path = Config.get_dir() / "tidal_token.json"
+    token.save()
+    typer.echo(f"Authentication successful! Tidal token saved to {token.file_path}.")

--- a/plistsync/services/tidal/library.py
+++ b/plistsync/services/tidal/library.py
@@ -10,7 +10,7 @@ from plistsync.core.collection import (
 )
 from plistsync.logger import log
 
-from .api import TidalApi, extract_tidal_playlist_id
+from .api import TidalApi, TidalApiSession, extract_tidal_playlist_id
 from .playlist import TidalPlaylistCollection
 from .track import TidalTrack
 
@@ -23,9 +23,9 @@ class TidalLibraryCollection(
 
     api: TidalApi
 
-    def __init__(self) -> None:
+    def __init__(self, session: TidalApiSession | None = None) -> None:
         super().__init__()
-        self.api = TidalApi()
+        self.api = TidalApi(session)
 
     # ------------------------ LibraryCollection protocol ------------------------ #
 

--- a/plistsync/utils/auth/bearer_token.py
+++ b/plistsync/utils/auth/bearer_token.py
@@ -6,14 +6,14 @@ json.
 
 import json
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime
-from functools import wraps
 from pathlib import Path
 from typing import (
     Any,
     ClassVar,
+    Generic,
     Self,
+    TypeVar,
 )
 
 import requests
@@ -21,50 +21,99 @@ from requests.structures import CaseInsensitiveDict
 from requests_oauth2client import BearerToken as BearerTokenOauth2Client
 from requests_oauth2client.tokens import ExpiredAccessToken
 
-from plistsync.config import Config
-from plistsync.errors import ConfigurationError
 
+class Token(ABC):
+    """Abstract base class for bearer tokens."""
 
-class BearerToken:
-    """Handles serialization and deserialization of token data."""
+    file_path: Path | None
+    """Path where the token should be persisted. None for memory-only tokens."""
 
-    def __init__(self, token: BearerTokenOauth2Client):
-        self.token = token
+    def __init__(self, file_path: Path | None) -> None:
+        self.file_path = file_path
+
+    @abstractmethod
+    def as_dict(self) -> dict[str, Any]:
+        """Get the token data as a dictionary."""
+        ...
 
     @classmethod
+    @abstractmethod
     def from_dict(cls, token_dict: dict[str, Any]) -> Self:
-        """Create a BearerToken instance from a dictionary."""
+        """Create token from dict."""
+        ...
+
+    @abstractmethod
+    def __call__(self, request: requests.PreparedRequest) -> requests.PreparedRequest:
+        """Prepare the request to use the authentication."""
+        ...
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the token is expired."""
+        return False
+
+    @classmethod
+    def from_file(cls, file_path: str | Path) -> Self:
+        """Create token instance from file."""
+        try:
+            with open(file_path) as f:
+                token_dict = json.load(f)
+            token = cls.from_dict(token_dict)
+            token.file_path = Path(file_path)
+            return token
+        except Exception as e:
+            raise InvalidTokenError(None) from e
+
+    def save(self):
+        """Persist token to :attr:`file_path`. Raises if file_path is None."""
+        if self.file_path is None:
+            raise ValueError("Cannot save token: file_path is None")
+        with open(self.file_path, "w") as f:
+            json.dump(self.as_dict(), f)
+
+
+class Oauth2Token(Token):
+    """Handles serialization and deserialization of token data."""
+
+    client: BearerTokenOauth2Client
+
+    def __init__(
+        self,
+        client: BearerTokenOauth2Client,
+        file_path: Path | None,
+    ) -> None:
+        super().__init__(file_path)
+        self.client = client
+
+    @staticmethod
+    def deserialize_dict(token_dict: dict[str, Any]) -> dict[str, Any]:
         if "expires_at" in token_dict:
             expires_at = token_dict.pop("expires_at")
             # Convert to datetime if it's a string
             if isinstance(expires_at, str):
                 expires_at = datetime.fromisoformat(expires_at)
             token_dict["expires_at"] = expires_at
-        return cls(BearerTokenOauth2Client(**token_dict))
+        return token_dict
+
+    def as_dict(self) -> dict[str, Any]:
+        """Get the token data as a dictionary."""
+        d = self.client.as_dict()
+        if self.client.expires_at is not None:
+            d["expires_at"] = self.client.expires_at.isoformat()
+        d.pop("expires_in", None)
+        return d
 
     @classmethod
-    def from_file(cls, file_path: str | Path) -> Self:
-        """Load token data from a JSON file."""
-        try:
-            with open(file_path) as f:
-                token_dict = json.load(f)
-            return cls.from_dict(token_dict)
-        except Exception as e:
-            raise InvalidTokenError(None) from e
+    def from_dict(cls, token_dict: dict[str, Any]) -> Self:
+        """Create a BearerToken instance from a dictionary."""
+        return cls(BearerTokenOauth2Client(cls.deserialize_dict(token_dict)), None)
 
-    def save(self, file_path: str | Path):
-        """Save token data to a JSON file."""
-        with open(file_path, "w") as f:
-            json.dump(self.as_dict(), f)
+    def update(self, token_data: dict[str, Any]) -> None:
+        """Update the token data in place."""
+        self.client = BearerTokenOauth2Client(**{**self.client.as_dict(), **token_data})
 
     def __call__(self, *args, **kwargs):
-        """Make the instance callable to add the Authorization header.
-
-        Usage:
-            token = BearerToken(...)
-            response = requests.get(url, auth=token)
-        """
-        return self.token(*args, **kwargs)
+        return self.client(*args, **kwargs)
 
     def __repr__(self):
         def mask(k: str, v: Any):
@@ -82,22 +131,10 @@ class BearerToken:
         res += ", ".join([f"{k}={mask(k, v)}" for k, v in self.as_dict().items()])
         return res + ")"
 
-    def as_dict(self) -> dict[str, Any]:
-        """Get the token data as a dictionary."""
-        d = self.token.as_dict()
-        if self.token.expires_at is not None:
-            d["expires_at"] = self.token.expires_at.isoformat()
-        d.pop("expires_in", None)
-        return d
-
-    def update(self, token_data: dict[str, Any]) -> None:
-        """Update the token data in place."""
-        self.token = BearerTokenOauth2Client(**{**self.token.as_dict(), **token_data})
-
     @property
     def is_expired(self) -> bool:
         """Check if the token is expired."""
-        expires_at = self.token.as_dict().get("expires_at")
+        expires_at = self.client.as_dict().get("expires_at")
         if expires_at is None:
             return False
         # Convert expires_at to datetime if it's a timestamp
@@ -107,7 +144,7 @@ class BearerToken:
 
 
 class InvalidTokenError(Exception):
-    def __init__(self, token: BearerToken | None):
+    def __init__(self, token: Token | None):
         if token:
             self.message = f"Invalid token: {token}"
         else:
@@ -115,7 +152,10 @@ class InvalidTokenError(Exception):
         super().__init__(self.message)
 
 
-class BearerTokenSession(requests.Session, ABC):
+T = TypeVar("T", bound=Token)
+
+
+class TokenSession(Generic[T], requests.Session, ABC):
     """A request session configured to use a bearer token.
 
     This session manages authentication for API requests by automatically
@@ -123,11 +163,8 @@ class BearerTokenSession(requests.Session, ABC):
     refresh when expired or rejected by the server.
     """
 
-    token: BearerToken
-    """The current bearer token used for authentication."""
-
-    token_path: Path | None
-    """Optional path to persist the token after refresh."""
+    token: T
+    """The current token used for authentication."""
 
     status_codes_expired: ClassVar[list[int]] = []
     """HTTP status codes indicating an expired/invalid token."""
@@ -137,21 +174,12 @@ class BearerTokenSession(requests.Session, ABC):
 
     def __init__(
         self,
-        token: BearerToken | None,
-        token_path: Path | None,
+        token: T,
     ) -> None:
         """Initialize the session with a token or token file."""
         super().__init__()
 
-        if token is None and token_path is not None:
-            token = BearerToken.from_file(token_path)
-        elif token is not None:
-            pass  # Use provided token
-        else:
-            raise ValueError("Either token or token path must be given!")
-
         self.token = token
-        self.token_path = token_path
 
     def request(
         self, method: str | bytes, url: str | bytes, *args, **kwargs
@@ -209,143 +237,13 @@ class BearerTokenSession(requests.Session, ABC):
     def refresh_token(self) -> None:
         """Refresh the token and persist it."""
         self._refresh_token()
-        if self.token_path is not None:
-            self.token.save(self.token_path)
-
-
-def requires_bearer_token(
-    config_key: str = "tidal",
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Add tidal token to function.
-
-    This decorator will load the token from the file if it exists. If the token does not
-    exist it will throw an error. If the token is expired, it will refresh the token.
-
-    Raises
-    ------
-    ConfigurationError
-        If the Tidal config is not available.
-    InvalidToken
-        If the token is not found or invalid.
-
-    Usage
-    -----
-
-    .. code-block:: python
-
-        @requires_bearer_token("tidal")
-        async def needs_tidal_token(token: BearerToken):
-            return token
-
-    Attention
-    ---------
-    This decorator will not work for generator functions. If you need to use the
-    `requires_bearer_token_generator` decorator.
-
-    Note: If you want to use this decorator in a route make sure to catch the
-    errors and redirect to the login route.
-
-    """
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            if "token" in kwargs:
-                return await func(*args, **kwargs)
-
-            token = get_bearer_token(config_key)
-            # Pass the token as a keyword argument
-            return await func(*args, token=token, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-def requires_bearer_token_generator(
-    config_key: str = "tidal",
-) -> Callable[
-    [Callable[..., AsyncGenerator[Any, None]]], Callable[..., AsyncGenerator[Any, None]]
-]:
-    """Add tidal token to generator function.
-
-    This decorator will load the token from the file if it exists. If the token does not
-    exist it will throw an error. If the token is expired, it will refresh the token.
-
-    Raises
-    ------
-    ConfigurationError
-        If the Tidal config is not available.
-    InvalidToken
-        If the token is not found or invalid.
-
-    Usage
-    -----
-
-    ```python
-    @requires_bearer_token_generator("tidal")
-    async def needs_bearer_token(token: BearerToken):
-        return token
-    ```
-
-    Attention
-    ---------
-    This decorator is for generator functions. If you need to use the
-    `requires_bearer_token` decorator.
-
-    Note: If you want to use this decorator in a route make sure to catch the
-    errors and redirect to the login route.
-    """
-
-    def decorator(
-        func: Callable[..., AsyncGenerator[Any, None]],
-    ) -> Callable[..., AsyncGenerator[Any, None]]:
-        @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any):
-            token = get_bearer_token()
-            # Pass the token as a keyword argument
-            async for res in func(*args, token=token, **kwargs):
-                yield res
-
-        return wrapper
-
-    return decorator
-
-
-def get_bearer_token(config_key: str = "tidal") -> BearerToken:
-    """Get the Tidal token.
-
-    Raises
-    ------
-    ConfigurationError
-        If the Tidal config is not available.
-    InvalidToken
-        If the token is not found or invalid.
-
-    """
-
-    # Check if the config is available
-    config = Config()
-    service_config = getattr(config, config_key, None)
-    if not service_config or not service_config.enabled:
-        raise ConfigurationError(
-            f"{config_key.capitalize()} config not available or {config_key}"
-            "integration disabled!",
-            config_key,
-        )
-
-    token_file = config.get_dir() / f"{config_key}_token.json"
-    try:
-        token = BearerToken.from_file(token_file)
-    except Exception as e:
-        raise InvalidTokenError(None) from e
-
-    return token
+        if self.token.file_path is not None:
+            self.token.save()
 
 
 __all__ = [
-    "BearerToken",
-    "requires_bearer_token",
-    "requires_bearer_token_generator",
-    "get_bearer_token",
+    "Token",
+    "Oauth2Token",
+    "TokenSession",
+    "InvalidTokenError",
 ]

--- a/plistsync/utils/auth/bearer_token.py
+++ b/plistsync/utils/auth/bearer_token.py
@@ -5,16 +5,21 @@ json.
 """
 
 import json
+from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime
 from functools import wraps
 from pathlib import Path
 from typing import (
     Any,
+    ClassVar,
     Self,
 )
 
+import requests
+from requests.structures import CaseInsensitiveDict
 from requests_oauth2client import BearerToken as BearerTokenOauth2Client
+from requests_oauth2client.tokens import ExpiredAccessToken
 
 from plistsync.config import Config
 from plistsync.errors import ConfigurationError
@@ -40,9 +45,12 @@ class BearerToken:
     @classmethod
     def from_file(cls, file_path: str | Path) -> Self:
         """Load token data from a JSON file."""
-        with open(file_path) as f:
-            token_dict = json.load(f)
-        return cls.from_dict(token_dict)
+        try:
+            with open(file_path) as f:
+                token_dict = json.load(f)
+            return cls.from_dict(token_dict)
+        except Exception as e:
+            raise InvalidTokenError(None) from e
 
     def save(self, file_path: str | Path):
         """Save token data to a JSON file."""
@@ -105,6 +113,104 @@ class InvalidTokenError(Exception):
         else:
             self.message = "Token not found. Have you created a token?"
         super().__init__(self.message)
+
+
+class BearerTokenSession(requests.Session, ABC):
+    """A request session configured to use a bearer token.
+
+    This session manages authentication for API requests by automatically
+    attaching bearer tokens to outgoing requests and handling token
+    refresh when expired or rejected by the server.
+    """
+
+    token: BearerToken
+    """The current bearer token used for authentication."""
+
+    token_path: Path | None
+    """Optional path to persist the token after refresh."""
+
+    status_codes_expired: ClassVar[list[int]] = []
+    """HTTP status codes indicating an expired/invalid token."""
+
+    status_codes_rate_limit: ClassVar[list[int]] = []
+    """HTTP status codes indicating rate limiting."""
+
+    def __init__(
+        self,
+        token: BearerToken | None,
+        token_path: Path | None,
+    ) -> None:
+        """Initialize the session with a token or token file."""
+        super().__init__()
+
+        if token is None and token_path is not None:
+            token = BearerToken.from_file(token_path)
+        elif token is not None:
+            pass  # Use provided token
+        else:
+            raise ValueError("Either token or token path must be given!")
+
+        self.token = token
+        self.token_path = token_path
+
+    def request(
+        self, method: str | bytes, url: str | bytes, *args, **kwargs
+    ) -> requests.Response:
+        """Send a request with token authentication.
+
+        Automatically handles token expiration and server-side token
+        rejection by refreshing and retrying once per failure mode.
+        """
+
+        if self.token.is_expired:
+            self._refresh_token()
+
+        # Always use token in auth
+        kwargs["auth"] = self.token
+
+        # Calling requests again can in theory
+        # create a infinite recursion but
+        # should not happen in practice (fingers crossed)
+        # we can add some max retry logic if this ever
+        # is an issue
+        try:
+            res = super().request(
+                method,
+                url,
+                *args,
+                **kwargs,
+            )
+        except ExpiredAccessToken:
+            self._refresh_token()
+            return self.request(method, url, *args, **kwargs)
+
+        if res.status_code in self.status_codes_expired:
+            self.refresh_token()
+            return self.request(method, url, *args, **kwargs)
+        elif res.status_code in self.status_codes_rate_limit:
+            self._handle_rate_limit(res.headers)
+            return self.request(method, url, *args, **kwargs)
+
+        return res
+
+    @abstractmethod
+    def _handle_rate_limit(self, headers: CaseInsensitiveDict) -> None:
+        """Handle a rate limit response from the server."""
+        ...
+
+    @abstractmethod
+    def _refresh_token(self) -> None:
+        """Fetch a new token from the API.
+
+        Implementations should update the token inplace.
+        """
+        ...
+
+    def refresh_token(self) -> None:
+        """Refresh the token and persist it."""
+        self._refresh_token()
+        if self.token_path is not None:
+            self.token.save(self.token_path)
 
 
 def requires_bearer_token(

--- a/plistsync/utils/auth/bearer_token.py
+++ b/plistsync/utils/auth/bearer_token.py
@@ -106,7 +106,7 @@ class Oauth2Token(Token):
     @classmethod
     def from_dict(cls, token_dict: dict[str, Any]) -> Self:
         """Create a BearerToken instance from a dictionary."""
-        return cls(BearerTokenOauth2Client(cls.deserialize_dict(token_dict)), None)
+        return cls(BearerTokenOauth2Client(**cls.deserialize_dict(token_dict)), None)
 
     def update(self, token_data: dict[str, Any]) -> None:
         """Update the token data in place."""


### PR DESCRIPTION
Recently while discussion #78 we noticed that the api layer is unnecessary coupled with the config. This makes working with the api a bit inconvenient especially for potential multi user workflows. 

This PR decouples the API layer from the config system and introduces a unified `Token`/`TokenSession` abstraction for handling authentication across services.

### Changes

**New `Token` abstraction** (`plistsync/utils/auth/bearer_token.py`):
- `Token` ABC - base class for all token types with file persistence built-in
- `Oauth2Token` - concrete implementation for OAuth2 tokens
- `TokenSession` - generic `requests.Session` subclass handling:
  - Proactive token refresh (before request if `is_expired`)
  - Reactive token refresh (on configurable status codes)
  - Rate limit handling (with backoff)
  - Automatic token persistence after refresh

**Service API refactors** (plex, spotify, tidal):
- APIs now accept `session` as a constructor parameter instead of reading config internally
- `from_config()` classmethod provides the config-to-API wiring
- Token persistence is handled by `TokenSession` automatically

### Example

```python
# Before (config coupled to API)
api = TidalApi()  # reads from config internally

# After (config decoupled, pass session explicitly)
token = Oauth2Token.from_file(user_token_path)
session = TidalApiSession(client_id=client_id, token=token)
api = TidalApi(session=session)

# Or use from_config when config is desired
api = TidalApi(session=TidalApiSession.from_config())
```
