### PR TITLE
Tidal api fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ with pl.edit():
 - In rare cases, spotify playlists can contain invalid items, which do not appear in the web interface (but through the api). We now filter and remove them.
 - Fixed an issue with the spotify api returning duplicate playlists on pagination borders.
 
+### Fixed
+
+- In rare cases, spotify playlists can contain invalid items, which do not appear in the web interface (but through the api). We now filter and remove them.
+
 ## [0.5.1] - 2026-03-16
 
 ### Fixed

--- a/plistsync/services/spotify/api.py
+++ b/plistsync/services/spotify/api.py
@@ -184,7 +184,7 @@ class PlaylistApi:
         force: bool = False,
     ) -> list[SpotifyApiPlaylistTrack]:
         """Resolve the track pagination."""
-        all_items: list[SpotifyApiPlaylistTrack] = data.get("items", [])
+        all_items: list[SpotifyApiPlaylistTrack] = data.get("items", [])  # type: ignore [assignment]
 
         next_page = data.get("next")
         if force or len(all_items) == 0:

--- a/plistsync/services/spotify/api.py
+++ b/plistsync/services/spotify/api.py
@@ -184,7 +184,7 @@ class PlaylistApi:
         force: bool = False,
     ) -> list[SpotifyApiPlaylistTrack]:
         """Resolve the track pagination."""
-        all_items: list[SpotifyApiPlaylistTrack] = data.get("items", [])  # type: ignore [assignment]
+        all_items: list[SpotifyApiPlaylistTrack] = data.get("items", [])
 
         next_page = data.get("next")
         if force or len(all_items) == 0:

--- a/plistsync/services/tidal/api.py
+++ b/plistsync/services/tidal/api.py
@@ -672,7 +672,7 @@ class TidalPlaylistApi:
         ids: list[str],
         item_type: str = "tracks",
         position_before: str | None = None,
-    ) -> requests.Response:
+    ):
         """Add items to a playlist.
 
         If position before is provided, add items before the given
@@ -682,25 +682,34 @@ class TidalPlaylistApi:
         if item_type not in ["tracks", "videos"]:
             raise ValueError('item_type must be either "tracks" or "videos"')
 
-        # Build the data array
-        data: list[dict[str, str]] = []
-        for item_id in ids:
-            item_data = {
-                "id": item_id,
-                "type": item_type,
-            }
-            data.append(item_data)
+        # Api does not like the request with empty list
+        if len(ids) == 0:
+            return
 
-        # Build the payload
-        payload: dict[str, Any] = {"data": data}
+        # max batch size is 20 (see tidal api docs, in the json schema)
+        batch_size = 20
+        for i in range(0, len(ids), batch_size):
+            batch = ids[i : i + batch_size]
 
-        # Add meta if position_before is specified
-        if position_before:
-            payload["meta"] = {"positionBefore": position_before}
+            # Build the data array
+            data: list[dict[str, str]] = []
+            for item_id in batch:
+                item_data = {
+                    "id": item_id,
+                    "type": item_type,
+                }
+                data.append(item_data)
 
-        return self.session.request(
-            "POST", f"/playlists/{playlist_id}/relationships/items", json=payload
-        )
+            # Build the payload
+            payload: dict[str, Any] = {"data": data}
+
+            # Add meta if position_before is specified
+            if position_before:
+                payload["meta"] = {"positionBefore": position_before}
+
+            _res = self.session.request(
+                "POST", f"/playlists/{playlist_id}/relationships/items", json=payload
+            )
 
     def reorder_items(
         self,
@@ -754,23 +763,32 @@ class TidalPlaylistApi:
         if item_type not in ["tracks", "videos"]:
             raise ValueError('item_type must be either "tracks" or "videos"')
 
-        data: list[dict[str, Any]] = []
-        for item_id in item_ids:
-            item_data = {
-                "id": item_id[0],
-                "meta": {"itemId": item_id[1]},
-                "type": item_type,
-            }
-            data.append(item_data)
+        # Api does not like the request with empty list
+        if len(item_ids) == 0:
+            return
 
-        # Build the payload
-        payload: dict[str, Any] = {"data": data}
+        # max batch size is 20 (see tidal api docs, in the json schema)
+        batch_size = 20
+        for i in range(0, len(item_ids), batch_size):
+            batch = item_ids[i : i + batch_size]
 
-        return self.session.request(
-            "DELETE",
-            f"/playlists/{playlist_id}/relationships/items",
-            json=payload,
-        )
+            data: list[dict[str, Any]] = []
+            for item_id in batch:
+                item_data = {
+                    "id": item_id[0],
+                    "meta": {"itemId": item_id[1]},
+                    "type": item_type,
+                }
+                data.append(item_data)
+
+            # Build the payload
+            payload: dict[str, Any] = {"data": data}
+
+            _res = self.session.request(
+                "DELETE",
+                f"/playlists/{playlist_id}/relationships/items",
+                json=payload,
+            )
 
 
 class TidalUserApi:

--- a/plistsync/services/tidal/api.py
+++ b/plistsync/services/tidal/api.py
@@ -687,10 +687,7 @@ class TidalPlaylistApi:
             return
 
         # max batch size is 20 (see tidal api docs, in the json schema)
-        batch_size = 20
-        for i in range(0, len(ids), batch_size):
-            batch = ids[i : i + batch_size]
-
+        for batch in chunk_list(ids, MAX_FILTER_SIZE):
             # Build the data array
             data: list[dict[str, str]] = []
             for item_id in batch:
@@ -768,10 +765,7 @@ class TidalPlaylistApi:
             return
 
         # max batch size is 20 (see tidal api docs, in the json schema)
-        batch_size = 20
-        for i in range(0, len(item_ids), batch_size):
-            batch = item_ids[i : i + batch_size]
-
+        for batch in chunk_list(item_ids, MAX_FILTER_SIZE):
             data: list[dict[str, Any]] = []
             for item_id in batch:
                 item_data = {

--- a/plistsync/services/tidal/api.py
+++ b/plistsync/services/tidal/api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from time import sleep
+import time
 from typing import Any, ClassVar, Literal, cast
 
 import requests
@@ -108,8 +108,8 @@ class TidalApiSession(TokenSession):
     def _handle_rate_limit(self, headers: CaseInsensitiveDict) -> None:
         remaining = int(headers.get("Retry-After", 0))
         if remaining > 0:
-            log.warning(f"Rate limit exceeded. Retrying after {remaining} seconds.")
-            sleep(remaining)
+            log.debug(f"Rate limit exceeded. Retrying after {remaining} seconds.")
+            time.sleep(remaining)
         else:
             raise Exception(
                 "Rate limit handling failed: Retry-After header is missing or invalid"

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -135,6 +135,7 @@ class TidalPlaylist(MultiRequestServicePlaylist[TidalPlaylistTrack]):
         tracks_before: list[TidalPlaylistTrack],
     ) -> None:
         track_ids = [t.id for t in track] if isinstance(track, list) else [track.id]
+
         if idx >= len(tracks_before):
             self.api.playlist.add_items(
                 playlist_id=self.id,


### PR DESCRIPTION
Based on #80 
(I needed both changes to get my sync script to run, and explore whats in the current PR)

- ~~add default rate limit of 4 requests per second on tidal, so we avoid 429 which slow us down even more~~
- batched inserts and deletions, to avoid server side errors that would occur for long lists of track changes via single request. No idea what the upper batch size is though, was hard to reproduce.