### PR TITLE
Spotify sometimes returns duplicates on pagination borders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ with pl.edit():
 
 - Fixed lazy track loading when playlist has 0 tracks (`force=True` logic in `_load_tracks`)
 - In rare cases, spotify playlists can contain invalid items, which do not appear in the web interface (but through the api). We now filter and remove them.
+- Fixed an issue with the spotify api returning duplicate playlists on pagination borders.
 
 ## [0.5.1] - 2026-03-16
 

--- a/plistsync/errors.py
+++ b/plistsync/errors.py
@@ -5,20 +5,7 @@ from eyconf.validation import ConfigurationError, MultiConfigurationError
 __all__ = [
     "ConfigurationError",
     "MultiConfigurationError",
-    "NotFoundError",
 ]
-
-
-class NotFoundError(Exception):
-    def __init__(self, message="Resource not found", resource=None):
-        self.message = message
-        self.resource = resource
-        super().__init__(self.message)
-
-    def __str__(self):
-        if self.resource:
-            return f"{self.message}: {self.resource}"
-        return self.message
 
 
 class DependencyError(ImportError):

--- a/plistsync/services/spotify/api.py
+++ b/plistsync/services/spotify/api.py
@@ -652,7 +652,12 @@ class UserApi:
             ).json()
             simplified_playlists.extend(json_res.get("items", []))
             next_page = json_res.get("next", None)
-        return simplified_playlists
+
+        # for some reason the spotify api returns the same playlists
+        # twice on pagination borders...
+        # we need to dedupe here
+        ids_to_playlists = {p["id"]: p for p in simplified_playlists}
+        return list(ids_to_playlists.values())
 
     def _get_playlists_full(self) -> list[SpotifyApiPlaylistResponseFull]:
         """Get the current user's playlists with full details.
@@ -669,7 +674,11 @@ class UserApi:
             playlist_data = self.api.playlist.get(plist["id"])
             playlists_details.append(playlist_data)
 
-        return playlists_details
+        # for some reason the spotify api returns the same playlists
+        # twice on pagination borders...
+        # we need to dedupe here
+        ids_to_playlists = {p["id"]: p for p in playlists_details}
+        return list(ids_to_playlists.values())
 
 
 def extract_spotify_playlist_id(url_or_uri: str) -> str | None:


### PR DESCRIPTION
Fixed an issue with the spotify api returning duplicate playlists on pagination borders.