### PR TITLE
Refactor track ID handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- Refactored track identifier handling across the codebase by replacing service-specific `TrackIds` dictionaries with strongly typed, immutable `TrackID` dataclasses for each service (e.g. Spotify, Plex).
 - Refactored playlist identifier handling across the codebase by replacing service-specific `PlaylistIds` dictionaries with strongly typed, immutable `PlaylistID` dataclasses for each service (e.g. Spotify, Plex). 
-- Removed obsolete playlist ID extraction utilities that are no longer required under the new identifier system.
-- Updated all playlist operations and internal synchronization flows to use the new typed identifier model consistently.
+  - Removed obsolete playlist ID extraction utilities that are no longer required under the new identifier system.
+  - Updated all playlist operations and internal synchronization flows to use the new typed identifier model consistently.
 
 This improves type safety, clarity, and extensibility for playlist identification and lookup operations. All playlist-related APIs and synchronization logic now operate on explicit identifier types instead of loosely structured dictionaries.
 

--- a/docs/services/plex/collections.ipynb
+++ b/docs/services/plex/collections.ipynb
@@ -41,19 +41,7 @@
    "execution_count": null,
    "id": "3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "106387 -> If I Could by ['Break, Jack Boston, Kyo']\n",
-      "106388 -> Betamax by ['Break, Total Science']\n",
-      "106389 -> Inside by ['Break, SpectraSoul']\n",
-      "106390 -> Ain't No Turnin' Back by ['Break']\n",
-      "106391 -> Free Your Mind - Break Remix by ['Break, Singing Fats']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Iterate over tracks\n",
     "for count, track in enumerate(library.tracks):\n",
@@ -100,18 +88,12 @@
    "execution_count": null,
    "id": "7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PlexTrack(artist='Break', title=\"Ain't No Turnin' Back\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from plistsync.services.plex import PlexTrackID\n",
+    "\n",
     "# By plex id\n",
-    "if plex_track := library.find_by_local_ids({\"plex_id\": \"106390\"}):\n",
+    "if plex_track := library.find_by_ids([PlexTrackID(\"14605\")]):\n",
     "    print(plex_track)"
    ]
   },
@@ -132,16 +114,7 @@
    "execution_count": null,
    "id": "9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "local_path=PosixPath('/Volumes/music/clean/Anile/Perspective/01 False Tense [996kbps].flac')\n",
-      "local_path.is_file()=True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
@@ -161,19 +134,13 @@
    "execution_count": null,
    "id": "10",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PlexTrack(artist='Break, Jack Boston, Kyo', title='If I Could')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from plistsync.core.ids import ISRC\n",
+    "\n",
     "# by isrc\n",
-    "if plex_track := library.find_by_global_ids(\n",
-    "    {\"isrc\": \"GBXJH1000082\"},\n",
+    "if plex_track := library.find_by_ids(\n",
+    "    [ISRC(\"GBXJH1000082\")],\n",
     "    path_rewrite=path_rewrite,\n",
     "):\n",
     "    print(plex_track)"
@@ -211,22 +178,10 @@
    "execution_count": null,
    "id": "13",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 110044 _42k (4 tracks)\n",
-      " 108489 _inbox (67 tracks)\n",
-      " 109614 _plistsync (5 tracks)\n",
-      " 108528 Abriss (13 tracks)\n",
-      " 106822 Bootlegish (34 tracks)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for count, pl in enumerate(library.playlists):\n",
-    "    print(f\"{pl.id:7d} {pl.name} ({len(pl)} tracks)\")\n",
+    "    print(f\"{pl.id} {pl.name} ({len(pl)} tracks)\")\n",
     "    if count == 4:\n",
     "        break"
    ]
@@ -282,15 +237,7 @@
    "execution_count": null,
    "id": "18",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Playlist did not exist, no need to delete\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    library.get_playlist_or_raise(name=\"My New Playlist\").delete()\n",
@@ -318,18 +265,7 @@
    "execution_count": null,
    "id": "20",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Updated description'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Updating a playlist description/name\n",
     "with pl.edit():\n",
@@ -343,21 +279,7 @@
    "execution_count": null,
    "id": "21",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[PlexTrack(artist='gyrofield', title='Fallen In Deep (Trail remix)'),\n",
-       " PlexTrack(artist='Rizzle', title='Mirage (Thread remix)'),\n",
-       " PlexTrack(artist='Rueben & PHI NIX', title='In My Mind (Tom Finster remix)'),\n",
-       " PlexTrack(artist='Skantia', title='2Drill (Calyx remix)')]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from plistsync.services.plex import PlexTrack\n",
     "\n",
@@ -365,12 +287,12 @@
     "new_tracks: list[PlexTrack] = list(\n",
     "    filter(\n",
     "        None,\n",
-    "        library.find_many_by_local_ids(\n",
+    "        library.find_many_by_ids(\n",
     "            [\n",
-    "                {\"plex_id\": \"111017\"},\n",
-    "                {\"plex_id\": \"111018\"},\n",
-    "                {\"plex_id\": \"111023\"},\n",
-    "                {\"plex_id\": \"111024\"},\n",
+    "                [PlexTrackID(\"111017\")],\n",
+    "                [PlexTrackID(\"111018\")],\n",
+    "                [PlexTrackID(\"111023\")],\n",
+    "                [PlexTrackID(\"111024\")],\n",
     "            ]\n",
     "        ),\n",
     "    )\n",
@@ -383,18 +305,7 @@
    "execution_count": null,
    "id": "22",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['111017', '111018', '111023', '111024']"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Add the tracks (until now the playlist is empty)\n",
     "with pl.edit():\n",
@@ -408,18 +319,7 @@
    "execution_count": null,
    "id": "23",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['111017', '111018', '111023']"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Remove a track\n",
     "with pl.edit():\n",
@@ -433,18 +333,7 @@
    "execution_count": null,
    "id": "24",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['111017', '111023', '111018']"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Change order\n",
     "with pl.edit():\n",
@@ -470,18 +359,7 @@
    "execution_count": null,
    "id": "26",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "OfflinePlaylist(name='My New Playlist', tracks=3)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "offline_pl = pl.delete()\n",
     "offline_pl"
@@ -500,15 +378,7 @@
    "execution_count": null,
    "id": "28",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Could not find playlist for {'id': 111295, 'ids': None}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    library.get_playlist_or_raise(id=pl.id)\n",
@@ -519,7 +389,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "plistsync",
    "language": "python",
    "name": "python3"
   },
@@ -533,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/services/spotify/collections.ipynb
+++ b/docs/services/spotify/collections.ipynb
@@ -41,23 +41,17 @@
    "execution_count": null,
    "id": "3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SpotifyTrack(artist='Origin Unknown', title='Valley of the Shadows')\n",
-      "SpotifyTrack(artist='Origin Unknown', title='Valley of the Shadows')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from plistsync.core.ids import ISRC\n",
+    "from plistsync.services.spotify import SpotifyTrackID\n",
+    "\n",
     "# By spotify id\n",
-    "if track1 := library.find_by_global_ids({\"spotify_id\": \"6fzwardfFs6sVfNA5R1ypt\"}):\n",
+    "if track1 := library.find_by_ids([SpotifyTrackID(\"6fzwardfFs6sVfNA5R1ypt\")]):\n",
     "    print(track1)\n",
     "\n",
     "# By isrc\n",
-    "if track2 := library.find_by_global_ids({\"isrc\": \"GBBZH9601601\"}):\n",
+    "if track2 := library.find_by_ids([ISRC(\"GBBZH9601601\")]):\n",
     "    print(track2)\n",
     "\n",
     "assert track1 == track2"
@@ -90,15 +84,7 @@
    "execution_count": null,
    "id": "6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Playlist: plistsync (3 tracks)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "playlists = library.playlists\n",
     "for playlist in playlists:\n",
@@ -118,15 +104,7 @@
    "execution_count": null,
    "id": "8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found playlist: plistsync (3 tracks)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# By name\n",
     "pl = library.get_playlist(\n",
@@ -191,18 +169,7 @@
    "execution_count": null,
    "id": "13",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Updated Description'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Updating a playlist description/name\n",
     "with pl.edit():\n",
@@ -224,24 +191,12 @@
    "execution_count": null,
    "id": "15",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[SpotifyPlaylistTrack(artist='Origin Unknown', title='Valley of the Shadows'),\n",
-       " SpotifyPlaylistTrack(artist='Break', title='If I Could')]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from plistsync.services.spotify import SpotifyPlaylistTrack\n",
     "\n",
-    "new_track_1 = library.find_by_global_ids({\"isrc\": \"GBBZH9601601\"})\n",
-    "new_track_2 = library.find_by_global_ids({\"isrc\": \"GBXJH1000082\"})\n",
+    "new_track_1 = library.find_by_ids([ISRC(\"GBBZH9601601\")])\n",
+    "new_track_2 = library.find_by_ids([ISRC(\"GBXJH1000082\")])\n",
     "assert new_track_1 is not None\n",
     "assert new_track_2 is not None\n",
     "\n",
@@ -291,18 +246,7 @@
    "execution_count": null,
    "id": "19",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "OfflinePlaylist(name='My New Playlist', tracks=2)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "offline_pl = pl.delete()\n",
     "offline_pl"
@@ -341,7 +285,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "plistsync",
    "language": "python",
    "name": "python3"
   },
@@ -355,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/services/tidal/collections.ipynb
+++ b/docs/services/tidal/collections.ipynb
@@ -41,23 +41,17 @@
    "execution_count": null,
    "id": "3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TidalTrack(artist='Origin Unknown', title='Valley Of The Shadows')\n",
-      "TidalTrack(artist='Origin Unknown', title='Valley Of The Shadows')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from plistsync.core.ids import ISRC\n",
+    "from plistsync.services.tidal import TidalTrackID\n",
+    "\n",
     "# By tidal id\n",
-    "if track1 := library.find_by_global_ids({\"isrc\": \"GBBZH9601601\"}):\n",
+    "if track1 := library.find_by_ids([TidalTrackID(\"490839595\")]):\n",
     "    print(track1)\n",
     "\n",
     "# By isrc\n",
-    "if track2 := library.find_by_global_ids({\"tidal_id\": \"490839595\"}):\n",
+    "if track2 := library.find_by_ids([ISRC(\"GBBZH9601601\")]):\n",
     "    print(track2)\n",
     "\n",
     "assert track1 == track2"
@@ -100,15 +94,7 @@
    "execution_count": null,
    "id": "7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Playlist: plistsync (3 tracks)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "playlists = library.playlists\n",
     "for playlist in playlists:\n",
@@ -128,15 +114,7 @@
    "execution_count": null,
    "id": "9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found playlist: plistsync (3 tracks)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl = library.get_playlist(\n",
     "    name=\"plistsync\"\n",
@@ -199,18 +177,7 @@
    "execution_count": null,
    "id": "14",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Updated Description'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Updating a playlist description/name\n",
     "with pl.edit():\n",
@@ -232,24 +199,12 @@
    "execution_count": null,
    "id": "16",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[TidalPlaylistTrack(artist='Origin Unknown', title='Valley Of The Shadows'),\n",
-       " TidalPlaylistTrack(artist='Kyo', title='If I Could')]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from plistsync.services.tidal import TidalPlaylistTrack\n",
     "\n",
-    "new_track_1 = library.find_by_global_ids({\"isrc\": \"GBBZH9601601\"})\n",
-    "new_track_2 = library.find_by_global_ids({\"isrc\": \"GBXJH1000082\"})\n",
+    "new_track_1 = library.find_by_ids([ISRC(\"GBBZH9601601\")])\n",
+    "new_track_2 = library.find_by_ids([ISRC(\"GBXJH1000082\")])\n",
     "assert new_track_1 is not None\n",
     "assert new_track_2 is not None\n",
     "\n",
@@ -311,18 +266,7 @@
    "execution_count": null,
    "id": "21",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "OfflinePlaylist(name='My New Playlist', tracks=2)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "offline_pl = pl.delete()\n",
     "offline_pl"
@@ -341,15 +285,7 @@
    "execution_count": null,
    "id": "23",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Playlist with id 334ffc4b-0c92-4f09-ae3b-26be2940ab56 not found\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
     "    library.get_playlist_or_raise(id=pl.id)\n",
@@ -368,7 +304,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "plistsync",
    "language": "python",
    "name": "python3"
   },
@@ -382,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/services/traktor/collections.ipynb
+++ b/docs/services/traktor/collections.ipynb
@@ -83,13 +83,15 @@
    "source": [
     "from pathlib import PurePath, PurePosixPath, PureWindowsPath\n",
     "\n",
+    "from plistsync.core.ids import FilePath\n",
+    "\n",
     "path: PurePath = PureWindowsPath(\n",
     "    r\"D:\\SYNC\\library\\Amoss, Fre4knc\\Watermark Volume 2\\04 Dragger [1028kbps].flac\"\n",
     ")\n",
     "path = PurePosixPath(\n",
     "    r\"/Volumes/Traktor/clean/Amoss, Fre4knc/Watermark Volume 2/04 Dragger [1028kbps].flac\"\n",
     ")\n",
-    "if track1 := library.find_by_local_ids({\"file_path\": path}):\n",
+    "if track1 := library.find_by_ids([FilePath(path)]):\n",
     "    print(track1)"
    ]
   },
@@ -134,15 +136,7 @@
    "execution_count": null,
    "id": "8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found playlist: plistsync (5 tracks)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl = library.get_playlist(\n",
     "    name=\"plistsync\"\n",
@@ -229,7 +223,7 @@
     "from plistsync.services.traktor import NMLPlaylistTrack\n",
     "\n",
     "# Add a track to the playlist\n",
-    "new_track = library.find_by_local_ids({\"file_path\": path})\n",
+    "new_track = library.find_by_ids([FilePath(path)])\n",
     "assert new_track is not None\n",
     "\n",
     "with pl.edit():\n",
@@ -294,18 +288,7 @@
    "execution_count": null,
    "id": "21",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "OfflinePlaylist(name='plistsync', tracks=5)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl.delete()"
    ]

--- a/examples/community/plex_traktor_bidirectional.py
+++ b/examples/community/plex_traktor_bidirectional.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 import typer
 
+from plistsync.core.ids import FilePath
 from plistsync.core.rewrite import PathRewrite
 from plistsync.logger import log
 from plistsync.services.plex.library import PlexLibrary
@@ -117,7 +118,7 @@ def main(
     with plex_playlist.edit():
         for p in missing_in_plex:
             p_for_plex = path_rewrite.invert.apply(p)
-            plex_track = plex_library.find_by_local_ids({"file_path": p_for_plex})
+            plex_track = plex_library.find_by_ids([FilePath(p_for_plex)])
             if plex_track is None:
                 log.warning(f"Could not find track in plex: {str(p_for_plex)}")
             else:

--- a/plistsync/core/__init__.py
+++ b/plistsync/core/__init__.py
@@ -7,8 +7,9 @@ and path rewriting.
 """
 
 from .collection import Collection, Library
+from .ids import PlaylistID
 from .matching import Matches
-from .playlist import Playlist, PlaylistID, ServicePlaylist
+from .playlist import Playlist, ServicePlaylist
 from .rewrite import PathRewrite
 from .track import GlobalTrackIDs, Track
 

--- a/plistsync/core/__init__.py
+++ b/plistsync/core/__init__.py
@@ -11,13 +11,14 @@ from .ids import PlaylistID, TrackID
 from .matching import Matches
 from .playlist import Playlist, ServicePlaylist
 from .rewrite import PathRewrite
-from .track import Track
+from .track import Track, TrackInfo
 
 __all__ = [
     "Collection",
     "Library",
     "PathRewrite",
     "Track",
+    "TrackInfo",
     "Playlist",
     "PlaylistID",
     "TrackID",

--- a/plistsync/core/__init__.py
+++ b/plistsync/core/__init__.py
@@ -7,20 +7,20 @@ and path rewriting.
 """
 
 from .collection import Collection, Library
-from .ids import PlaylistID
+from .ids import PlaylistID, TrackID
 from .matching import Matches
 from .playlist import Playlist, ServicePlaylist
 from .rewrite import PathRewrite
-from .track import GlobalTrackIDs, Track
+from .track import Track
 
 __all__ = [
     "Collection",
     "Library",
     "PathRewrite",
     "Track",
-    "GlobalTrackIDs",
     "Playlist",
     "PlaylistID",
+    "TrackID",
     "ServicePlaylist",
     "Matches",
 ]

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -82,7 +82,7 @@ class IDLookup(Protocol, Generic[T]):
         ...
 
     def find_many_by_ids(
-        self, ids_iter: Iterable[Iterable[TrackID]]
+        self, track_ids_batch: Iterable[Iterable[TrackID]]
     ) -> Iterable[T | None]:
         """Find multiple tracks by their identifiers.
 
@@ -90,7 +90,7 @@ class IDLookup(Protocol, Generic[T]):
         ``find_by_ids`` for each entry. Collections can override this
         method to provide a more efficient batch lookup if supported.
         """
-        for ids in ids_iter:
+        for ids in track_ids_batch:
             yield self.find_by_ids(ids)
 
 
@@ -261,6 +261,7 @@ class Collection(ABC, Generic[T]):
         has_id_lookup = isinstance(self, IDLookup)
         has_info_lookup = isinstance(self, InfoLookup)
         is_stream = isinstance(self, TrackStream)
+        found_track: T
 
         # 1. ID lookup (global)
         # We search global ids first

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -65,7 +65,9 @@ P = ParamSpec("P")
 T = TypeVar("T", bound=Track, covariant=True)
 
 if TYPE_CHECKING:
-    from .playlist import Playlist, PlaylistID
+    from .ids import PlaylistID
+    from .playlist import Playlist
+
 
 Plist = TypeVar("Plist", bound="Playlist", default="Playlist", covariant=True)
 

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -77,11 +77,13 @@ class IDLookup(Protocol, Generic[T]):
     """A collection that can find tracks by their :class:`TrackID` identifiers."""
 
     @abstractmethod
-    def find_by_ids(self, ids: set[TrackID]) -> T | None:
+    def find_by_ids(self, ids: Iterable[TrackID]) -> T | None:
         """Find a single track by its identifiers."""
         ...
 
-    def find_many_by_ids(self, ids_iter: Iterable[set[TrackID]]) -> Iterable[T | None]:
+    def find_many_by_ids(
+        self, ids_iter: Iterable[Iterable[TrackID]]
+    ) -> Iterable[T | None]:
         """Find multiple tracks by their identifiers.
 
         Default implementation iterates over the provided list and calls

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -10,8 +10,7 @@ Key Design Principles:
 1. Capability-based Design:
    Collections declare what operations they support by implementing specific protocols:
 
-   - **GlobalLookup**: Enables exact matching via globally unique identifiers.
-   - **LocalLookup**: Supports context-specific identifier matching.
+   - **IDLookup**: Enables exact matching via track identifiers (global or local).
    - **InfoLookup**: Facilitates metadata-based similarity searches.
    - **TrackStream**: Provides iteration and bulk processing abilities.
 
@@ -36,7 +35,7 @@ all relevant capabilities offered by the collection.
 
 .. code-block:: python
 
-    class MyTrackCollection(Collection, GlobalLookup, LocalLookup, TrackStream):
+    class MyTrackCollection(Collection, IDLookup, TrackStream):
         # Implement required methods...
 """
 
@@ -57,8 +56,9 @@ from typing import (
 
 from typing_extensions import TypeVar
 
+from .ids import Scope, TrackID
 from .matching import Matches, Similarity, fuzzy_match
-from .track import GlobalTrackIDs, LocalTrackIDs, Track, TrackInfo
+from .track import Track, TrackInfo
 
 R = TypeVar("R")
 P = ParamSpec("P")
@@ -73,50 +73,23 @@ Plist = TypeVar("Plist", bound="Playlist", default="Playlist", covariant=True)
 
 
 @runtime_checkable
-class GlobalLookup(Protocol, Generic[T]):
-    """A collection that can find tracks using global unique IDs."""
+class IDLookup(Protocol, Generic[T]):
+    """A collection that can find tracks by their :class:`TrackID` identifiers."""
 
     @abstractmethod
-    def find_by_global_ids(self, global_ids: GlobalTrackIDs) -> T | None:
-        """Find a single track by its global identifiers."""
+    def find_by_ids(self, ids: set[TrackID]) -> T | None:
+        """Find a single track by its identifiers."""
         ...
 
-    def find_many_by_global_ids(
-        self, global_ids_list: Iterable[GlobalTrackIDs]
-    ) -> Iterable[T | None]:
-        """Find multiple tracks by their global identifiers.
+    def find_many_by_ids(self, ids_iter: Iterable[set[TrackID]]) -> Iterable[T | None]:
+        """Find multiple tracks by their identifiers.
 
         Default implementation iterates over the provided list and calls
-        `find_by_global_ids` for each entry. Collections can override this
+        ``find_by_ids`` for each entry. Collections can override this
         method to provide a more efficient batch lookup if supported.
         """
-        for global_ids in global_ids_list:
-            yield self.find_by_global_ids(global_ids)
-
-
-@runtime_checkable
-class LocalLookup(Protocol, Generic[T]):
-    """A collection that can find tracks using local context-specific IDs."""
-
-    @abstractmethod
-    def find_by_local_ids(self, local_ids: LocalTrackIDs) -> T | None:
-        """Find a single track by its local identifiers."""
-        # TODO: local ids might potentially return multiple tracks.
-        # Not decided how to handle this 100% yet. For now, we raise warnings
-        # and return the first match. (Same goes for global ids, actually.)
-        ...
-
-    def find_many_by_local_ids(
-        self, local_ids_list: Iterable[LocalTrackIDs]
-    ) -> Iterable[T | None]:
-        """Find multiple tracks by their local identifiers.
-
-        Default implementation iterates over the provided list and calls
-        `find_by_local_ids` for each entry. Collections can override this
-        method to provide a more efficient batch lookup if supported.
-        """
-        for local_ids in local_ids_list:
-            yield self.find_by_local_ids(local_ids)
+        for ids in ids_iter:
+            yield self.find_by_ids(ids)
 
 
 @runtime_checkable
@@ -259,8 +232,8 @@ class Collection(ABC, Generic[T]):
 
         The method checks for matches in this order:
 
-        1. Global IDs (exact match, returns immediately if found)
-        2. Local IDs (exact match with similarity check)
+        1. IDs with global scope (exact match, returns immediately if found)
+        2. IDs with local scope (exact match with similarity check)
         3. Track info (similarity-based search)
         4. Fallback to iterating through all tracks if needed.
            This still uses the three methods above, but is way less efficient.
@@ -283,23 +256,26 @@ class Collection(ABC, Generic[T]):
 
         # Check capabilities of this collection,
         # protocol instance checks can be expensive
-        has_global_lookup = isinstance(self, GlobalLookup)
-        has_local_lookup = isinstance(self, LocalLookup)
+        has_id_lookup = isinstance(self, IDLookup)
         has_info_lookup = isinstance(self, InfoLookup)
         is_stream = isinstance(self, TrackStream)
 
-        # 1. Try global ID lookup first (exact match, highest priority)
-        if has_global_lookup:
-            if found_track := self.find_by_global_ids(track.global_ids):  # type: ignore[attr-defined]
+        # 1. ID lookup (global)
+        # We search global ids first
+        # (exact match, highest priority)
+        global_ids = {id for id in track.ids if id.scope is Scope.GLOBAL}
+        if has_id_lookup and global_ids:
+            if found_track := self.find_by_ids(global_ids):  # type: ignore[attr-defined]
                 return Matches(
                     truth=track, found=[found_track], found_similarities=[1.0]
                 )
 
-        # 2. Try local ID lookup (exact match with similarity check)
-        if has_local_lookup:
-            if found_track := self.find_by_local_ids(track.local_ids):  # type: ignore[attr-defined]
+        # 2. ID lookup (local)
+        # (exact match with similarity check)
+        local_ids = {id for id in track.ids if id.scope is Scope.LOCAL}
+        if has_id_lookup and local_ids:
+            if found_track := self.find_by_ids(local_ids):  # type: ignore[attr-defined]
                 similarity = _fuzzy_match_track(track, found_track)
-
                 if similarity >= cutoff:
                     found_tracks.append(found_track)
                     similarities.append(similarity)
@@ -336,38 +312,35 @@ class Collection(ABC, Generic[T]):
         # 4. Fallback to iterating through all tracks,
         # but only if the collection does not implement all other protocols
         # (in this case, we have already checked all three options)
-        if is_stream and not (
-            has_global_lookup and has_local_lookup and has_info_lookup
-        ):
+        if is_stream and not (has_id_lookup and has_info_lookup):
             # TODO: we might to skip the fuzzy match for the global
             # id case
             for similarity, found_track in self.map_threadpool(  # type: ignore[attr-defined]
                 _fuzzy_match_track, chunk_size=1000, b=track
             ):
-                if not has_global_lookup:
-                    for key, value in track.global_ids.items():
-                        if found_track.global_ids.get(key) == value:
-                            return Matches(
-                                truth=track,
-                                found=[found_track],
-                                found_similarities=[1.0],
-                            )
+                # Again global scope first
+                if not has_id_lookup:
+                    if global_ids & found_track.ids:  # Intersection
+                        return Matches(
+                            truth=track,
+                            found=[found_track],
+                            found_similarities=[1.0],
+                        )
 
                 if similarity < cutoff:
                     continue
 
-                if not has_local_lookup:
-                    for key, value in track.local_ids.items():
-                        if found_track.local_ids.get(key) == value:
-                            found_tracks.append(found_track)
-                            similarities.append(similarity)
+                if not has_id_lookup:
+                    if local_ids & found_track.ids:
+                        found_tracks.append(found_track)
+                        similarities.append(similarity)
 
-                            if skip_after_local_match:
-                                return Matches(
-                                    truth=track,
-                                    found=found_tracks,
-                                    found_similarities=similarities,
-                                )
+                        if skip_after_local_match:
+                            return Matches(
+                                truth=track,
+                                found=found_tracks,
+                                found_similarities=similarities,
+                            )
 
                 if not has_info_lookup:
                     found_tracks.append(found_track)

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -1,0 +1,175 @@
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import PurePath
+from typing import ClassVar, Self
+
+
+@dataclass(frozen=True)
+class PlaylistID(ABC):
+    """Immutable base for service-specific playlist identifiers.
+
+    Decouples the service-specific representation from the generic playlist
+    management logic.
+
+    Should contain a unique identifier for a playlist
+    within a specific service.
+    Should not be passed down to the API layer of a service.
+    There, the native, service-specific representation should be used,
+    e.g. a simple `id` string for spotify, or the int `id` for plex.
+
+    We need this abstraction to allow us to load and save playlists in a generic
+    way i.e. to implement the loading logic only once but have it work for
+    all services.
+    """
+
+    @classmethod
+    @abstractmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from user input (URL, URI, or raw id)."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def serial(self) -> str:
+        """
+        Plistsync's internal string-representation of service specific playlist ID.
+
+        By convention it should look like `service_name:your_custom:format` e.g.
+        `spotify:playlist:actual_id`. This is not enforced but recommended.
+
+        By convention, to get the _canonical_ representation that the service API
+        understands, you should define `__str__` or `__int__` methods to get the
+        shorter and convenient values.
+        """
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(serial={self.serial!r})"
+
+
+class Scope(Enum):
+    """Scope in which the id can be used.
+
+    This determines matching behavior of the id.
+    """
+
+    GLOBAL = "global"
+    LOCAL = "local"
+
+
+@dataclass(frozen=True)
+class TrackID(ABC):
+    """Immutable base for service-specific track identifiers.
+
+    Decouples the service-specific representation from the generic track
+    management logic.
+
+    Should contain a unique identifier for a track
+    within a specific service.
+    Should not be passed down to the API layer of a service.
+    There, the native, service-specific representation should be used,
+    e.g. a simple `id` string for spotify, or the int `id` for plex.
+
+    We need this abstraction to allow us to load and save tracks in a generic
+    way i.e. to implement the loading logic only once but have it work for
+    all services.
+    """
+
+    scope: ClassVar[Scope] = Scope.GLOBAL
+
+    @classmethod
+    @abstractmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from user input (URL, URI, or raw id)."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def serial(self) -> str:
+        """
+        Plistsync's internal string-representation of service specific track ID.
+
+        By convention it should look like `service_name:your_custom:format` e.g.
+        `spotify:track:actual_id`. This is not enforced but recommended.
+
+        By convention, to get the _canonical_ representation that the service API
+        understands, you should define `__str__` or `__int__` methods to get the
+        shorter and convenient values.
+        """
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(serial={self.serial!r})"
+
+
+# Commonly shared IDS
+
+
+@dataclass(frozen=True)
+class ISRC(TrackID):
+    """International Standard Recording Code.
+
+    A standardized identifier intended to be globally unique for a recording.
+    """
+
+    id: str
+    """The raw 12-character ISRC (e.g. ``USRC17607839``)."""
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from user input (URL, URI, serial, or raw id).
+
+        Accepts both the raw 12-character ISRC and the serial format
+        (``isrc:XXAAA0000000``).
+        """
+        value = value.strip()
+        # Strip optional serial prefix
+        if value.lower().startswith("isrc:"):
+            value = value[5:]
+        value = value.upper()
+        # Validate ISRC format: 12 characters, alphanumeric
+        if not re.fullmatch(r"[A-Z]{2}[A-Z0-9]{3}\d{7}", value):
+            raise ValueError(f"Invalid ISRC: {value!r}")
+        return cls(value)
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal string-representation of ISRC."""
+        return f"isrc:{self.id}"
+
+    def __str__(self) -> str:
+        """Compact display (just the raw id)."""
+        return self.id
+
+
+@dataclass(frozen=True)
+class FilePath(TrackID):
+    """File path identifier for local tracks.
+
+    This is a simple wrapper around a file path, used to identify local tracks in a
+    consistent way.
+    """
+
+    scope: ClassVar[Scope] = Scope.LOCAL
+
+    path: PurePath
+    """The filesystem path to the track file."""
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from user input (raw path or serial ``file:...`` format)."""
+        value = value.strip()
+        if value.lower().startswith("file:"):
+            value = value[5:]
+        return cls(PurePath(value))
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal string-representation of the file path."""
+        return f"file:{self.path.as_posix()}"
+
+    def __str__(self) -> str:
+        """Compact display (just the raw path string)."""
+        return str(self.path)

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -121,13 +121,15 @@ class ISRC(TrackID):
     def parse(cls, value: str) -> Self:
         """Parse from user input (URL, URI, serial, or raw id).
 
-        Accepts both the raw 12-character ISRC and the serial format
-        (``isrc:XXAAA0000000``).
+        Accepts the raw 12-character ISRC, the serial format
+        (``isrc:XXAAA0000000``), or the dashed format (``XX-AAA-00-00000``).
         """
         value = value.strip()
         # Strip optional serial prefix
         if value.lower().startswith("isrc:"):
             value = value[5:]
+        # Strip dashes from standard notation (e.g. US-AT1-99-00001)
+        value = value.replace("-", "")
         value = value.upper()
         # Validate ISRC format: 12 characters, alphanumeric
         if not re.fullmatch(r"[A-Z]{2}[A-Z0-9]{3}\d{7}", value):

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -112,10 +112,17 @@ class ISRC(TrackID):
     """International Standard Recording Code.
 
     A standardized identifier intended to be globally unique for a recording.
+
+    The ``id`` field is always normalised (uppercase, dashes stripped)
+    regardless of how the instance is constructed.
     """
 
     id: str
     """The raw 12-character ISRC (e.g. ``USRC17607839``)."""
+
+    def __init__(self, value: str) -> None:
+        normalised = value.replace("-", "").upper()
+        object.__setattr__(self, "id", normalised)
 
     @classmethod
     def parse(cls, value: str) -> Self:
@@ -125,14 +132,12 @@ class ISRC(TrackID):
         (``isrc:XXAAA0000000``), or the dashed format (``XX-AAA-00-00000``).
         """
         value = value.strip()
-        # Strip optional serial prefix
         if value.lower().startswith("isrc:"):
             value = value[5:]
-        # Strip dashes from standard notation (e.g. US-AT1-99-00001)
-        value = value.replace("-", "")
-        value = value.upper()
-        # Validate ISRC format: 12 characters, alphanumeric
-        if not re.fullmatch(r"[A-Z]{2}[A-Z0-9]{3}\d{7}", value):
+        # __init__ handles dash-stripping and uppercasing
+        if not re.fullmatch(
+            r"[A-Z]{2}[A-Z0-9]{3}\d{7}", value.replace("-", "").upper()
+        ):
             raise ValueError(f"Invalid ISRC: {value!r}")
         return cls(value)
 

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -30,50 +30,8 @@ from typing_extensions import TypeVar
 
 from .collection import Collection, Library, TrackStream
 from .diff import DeleteOp, InsertOp, MoveOp, batch_consecutive, list_diff
+from .ids import PlaylistID
 from .track import OfflineTrack, Track
-
-
-@dataclass(frozen=True)
-class PlaylistID(ABC):
-    """Immutable base for service-specific playlist identifiers.
-
-    Decouples the service-specific representation from the generic playlist
-    management logic.
-
-    Should contain a unique identifier for a playlist
-    within a specific service.
-    Should not be passed down to the API layer of a service.
-    There, the native, service-specific representation should be used,
-    e.g. a simple `id` string for spotify, or the int `id` for plex.
-
-    We need this abstraction to allow us to load and save playlists in a generic
-    way i.e. to implement the loading logic only once but have it work for
-    all services.
-    """
-
-    @classmethod
-    @abstractmethod
-    def parse(cls, value: str) -> Self:
-        """Parse from user input (URL, URI, or raw id)."""
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def serial(self) -> str:
-        """
-        Plistsync's internal string-representation of service specific ID.
-
-        By convention it should look like `service_name:your_custom:format` e.g.
-        `spotify:playlist:actual_id`. This is not enforced but recommended.
-
-        By convention, to get the _canonical_ representation that the service API
-        understands, you should define `__str__` or `__int__` methods to get the
-        shorter and convenient values.
-        """
-        raise NotImplementedError
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}(serial={self.serial!r})"
 
 
 class PlaylistInfo(TypedDict, total=False):

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -24,7 +24,7 @@ from collections.abc import Hashable, Sequence
 from contextlib import contextmanager
 from copy import copy, deepcopy
 from dataclasses import dataclass
-from typing import ClassVar, Generic, Self, TypedDict
+from typing import Generic, Self, TypedDict
 
 from typing_extensions import TypeVar
 
@@ -37,6 +37,9 @@ from .track import OfflineTrack, Track
 class PlaylistID(ABC):
     """Immutable base for service-specific playlist identifiers.
 
+    Decouples the service-specific representation from the generic playlist
+    management logic.
+
     Should contain a unique identifier for a playlist
     within a specific service.
     Should not be passed down to the API layer of a service.
@@ -44,11 +47,9 @@ class PlaylistID(ABC):
     e.g. a simple `id` string for spotify, or the int `id` for plex.
 
     We need this abstraction to allow us to load and save playlists in a generic
-    way — i.e. to implement the loading logic only once but have it work for
+    way i.e. to implement the loading logic only once but have it work for
     all services.
     """
-
-    service_name: ClassVar[str]
 
     @classmethod
     @abstractmethod
@@ -62,8 +63,8 @@ class PlaylistID(ABC):
         """
         Plistsync's internal string-representation of service specific ID.
 
-        Should at least look like `service_name:your_custom:format` but
-        recommended to be similar to e.g. `spotify:playlist:actual_id`.
+        By convention it should look like `service_name:your_custom:format` e.g.
+        `spotify:playlist:actual_id`. This is not enforced but recommended.
 
         By convention, to get the _canonical_ representation that the service API
         understands, you should define `__str__` or `__int__` methods to get the

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -3,74 +3,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from copy import copy
 from pathlib import PurePath
 from typing import TypedDict
 
-
-class GlobalTrackIDs(TypedDict, total=False):
-    """Global Unique identifiers for a track.
-
-    Each identifier in this collection should uniquely identify a track
-    across all systems and collections. Unlike local identifiers, these
-    are intended to allow unambiguous track matching across devices,
-    libraries, or services.
-
-    Corresponds to collections-protocol `GlobalLookup`.
-    """
-
-    tidal_id: str
-    """Tidal ID of the track.
-
-    Globally unique within the Tidal service.
-    """
-
-    isrc: str
-    """International Standard Recording Code.
-
-    A standardized identifier intended to be globally unique for a recording.
-    TODO: A track may have multiple ISRCs (e.g., different releases or regions),
-    so this field may need to support multiple values in the future.
-    """
-
-    spotify_id: str
-    """Spotify ID of the track.
-
-    Globally unique within the Spotify service.
-    """
-
-
-class LocalTrackIDs(TypedDict, total=False):
-    """Locally scoped identifiers for a track.
-
-    These identifiers are unique only within a specific collection or context,
-    such as a local library, playlist, database, or device. They are intended
-    for identifying a track within that local scope and may not be unique globally.
-
-    Corresponds to collections-protocol `LocalLookup`.
-    """
-
-    file_path: PurePath
-    """Local (pure) filesystem path to the track file.
-
-    This is not globally unique because file paths may differ across devices
-    or mount points, even if the underlying track is the same.
-    (This is also why we use PurePath, which is OS-agnostic, instead of Path.)
-    """
-
-    beets_id: int
-    """Track ID from a local Beets library.
-
-    Unique only within a local Beets library. Different libraries may assign
-    different IDs to the same track.
-    """
-
-    plex_id: str
-    """Track ID from a Plex media server library.
-
-    Unique only within a single Plex library. The same track in another Plex
-    server or library may have a different ID.
-    """
+from plistsync.core.ids import ISRC, FilePath, TrackID
+from plistsync.logger import log
 
 
 class TrackInfo(TypedDict, total=False):
@@ -106,14 +45,8 @@ class Track(ABC):
 
     @property
     @abstractmethod
-    def global_ids(self) -> GlobalTrackIDs:
-        """The globally unique identifiers of this track."""
-        ...
-
-    @property
-    @abstractmethod
-    def local_ids(self) -> LocalTrackIDs:
-        """The locally unique identifiers of this track."""
+    def ids(self) -> set[TrackID]:
+        """The identifiers of this track."""
         ...
 
     # ----------------------------- Info Getters ----------------------------- #
@@ -143,12 +76,18 @@ class Track(ABC):
     @property
     def path(self) -> PurePath | None:
         """The path to the file of the track."""
-        return self.local_ids.get("file_path", None)
+        paths = [id.path for id in self.ids if isinstance(id, FilePath)]
+        if len(paths) > 1:
+            log.warning(f"Found multiple paths: {paths}. Using the first one.")
+        return paths[0] if paths else None
 
     @property
     def isrc(self) -> str | None:
         """International Standard Recording Code."""
-        return self.global_ids.get("isrc", None)
+        isrcs = [id.id for id in self.ids if isinstance(id, ISRC)]
+        if len(isrcs) > 1:
+            log.warning(f"Found multiple ISRCs: {isrcs}. Using the first one.")
+        return isrcs[0] if isrcs else None
 
     @property
     def primary_artist(self) -> str | None:
@@ -157,8 +96,6 @@ class Track(ABC):
         If the track has no artist, return an empty string.
         """
         return self.artists[0] if self.artists else None
-
-    # --------------------------------- Contracts -------------------------------- #
 
     # ----------------------------------- Other ---------------------------------- #
 
@@ -174,17 +111,11 @@ class Track(ABC):
             if v1 != v2:
                 diffs[f"info.{key}"] = (v1, v2)
 
-        # Compare global_ids fields
-        for key in set(track1.global_ids.keys()).union(track2.global_ids.keys()):
-            v1, v2 = track1.global_ids.get(key), track2.global_ids.get(key)
-            if v1 != v2:
-                diffs[f"global_ids.{key}"] = (v1, v2)
-
-        # Compare local_ids fields
-        for key in set(track1.local_ids.keys()).union(track2.local_ids.keys()):
-            v1, v2 = track1.local_ids.get(key), track2.local_ids.get(key)
-            if v1 != v2:
-                diffs[f"local_ids.{key}"] = (v1, v2)
+        # Compare ids by serial
+        ids1 = {id.serial for id in track1.ids}
+        ids2 = {id.serial for id in track2.ids}
+        if ids1 != ids2:
+            diffs["ids"] = (ids1 - ids2, ids2 - ids1)
 
         return diffs
 
@@ -195,11 +126,7 @@ class Track(ABC):
 
         # TODO: Design choice:
         # when is a track from another serivce the same track?
-        return (
-            self.info == other.info
-            and self.global_ids == other.global_ids
-            and self.local_ids == other.local_ids
-        )
+        return self.info == other.info and self.ids == other.ids
 
     def __hash__(self) -> int:
         """Generate a hash based on the track's data."""
@@ -210,10 +137,9 @@ class Track(ABC):
                 for k, v in self.info.items()
             )
         )
-        global_ids_hash = tuple(sorted(self.global_ids.items()))
-        local_ids_hash = tuple(sorted(self.local_ids.items()))
+        ids_hash = hash(frozenset(self.ids))
 
-        return hash((info_hash, global_ids_hash, local_ids_hash))
+        return hash((info_hash, ids_hash))
 
     def __repr__(self) -> str:
         cls = type(self).__name__
@@ -231,30 +157,23 @@ class OfflineTrack(Track):
     """
 
     _info: TrackInfo
-    _local_ids: LocalTrackIDs
-    _global_ids: GlobalTrackIDs
+    _ids: set[TrackID]
 
     def __init__(
         self,
         info: TrackInfo,
-        local_ids: LocalTrackIDs | None = None,
-        global_ids: GlobalTrackIDs | None = None,
+        ids: Iterable[TrackID] | None = None,
     ):
         self._info = info
-        self._local_ids = local_ids or {}
-        self._global_ids = global_ids or {}
+        self._ids = set(ids) if ids is not None else set()
 
     @property
     def info(self) -> TrackInfo:
         return self._info
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        return self._global_ids
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        return self._local_ids
+    def ids(self) -> set[TrackID]:
+        return self._ids
 
     def merge(self, track: Track) -> OfflineTrack:
         """Merge another track into this one.
@@ -265,15 +184,12 @@ class OfflineTrack(Track):
         info = copy(self.info)
         info.update(track.info)
 
-        local_ids = copy(self.local_ids)
-        local_ids.update(track.local_ids)
+        ids = copy(self.ids)
+        ids.update(track.ids)
 
-        global_ids = copy(self.global_ids)
-        global_ids.update(track.global_ids)
-
-        return OfflineTrack(info, local_ids, global_ids)
+        return OfflineTrack(info, ids)
 
     @classmethod
     def from_track(cls, track: Track) -> OfflineTrack:
         """Create a offline track from arbitrary other track."""
-        return cls(track.info, track.local_ids, track.global_ids)
+        return cls(track.info, track.ids)

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -45,7 +45,7 @@ class Track(ABC):
 
     @property
     @abstractmethod
-    def ids(self) -> set[TrackID]:
+    def ids(self) -> frozenset[TrackID]:
         """The identifiers of this track."""
         ...
 
@@ -157,7 +157,7 @@ class OfflineTrack(Track):
     """
 
     _info: TrackInfo
-    _ids: set[TrackID]
+    _ids: frozenset[TrackID]
 
     def __init__(
         self,
@@ -165,14 +165,14 @@ class OfflineTrack(Track):
         ids: Iterable[TrackID] | None = None,
     ):
         self._info = info
-        self._ids = set(ids) if ids is not None else set()
+        self._ids = frozenset(ids) if ids is not None else frozenset()
 
     @property
     def info(self) -> TrackInfo:
         return self._info
 
     @property
-    def ids(self) -> set[TrackID]:
+    def ids(self) -> frozenset[TrackID]:
         return self._ids
 
     def merge(self, track: Track) -> OfflineTrack:
@@ -184,7 +184,7 @@ class OfflineTrack(Track):
         info = copy(self.info)
         info.update(track.info)
 
-        ids = copy(self.ids)
+        ids = set(self.ids)
         ids.update(track.ids)
 
         return OfflineTrack(info, ids)

--- a/plistsync/services/beets/collection.py
+++ b/plistsync/services/beets/collection.py
@@ -4,15 +4,15 @@ from typing import Any
 
 from sqlalchemy import Row, String, cast, select
 
-from plistsync.core.collection import Collection, GlobalLookup, LocalLookup, TrackStream
-from plistsync.core.track import GlobalTrackIDs, LocalTrackIDs
+from plistsync.core import TrackID
+from plistsync.core.collection import Collection, IDLookup, TrackStream
+from plistsync.core.ids import ISRC, FilePath
 
-from ...logger import log
 from .database import BeetsDatabase
-from .track import BeetsTrack
+from .track import BeetsTrack, BeetsTrackID
 
 
-class BeetsCollection(Collection, TrackStream, GlobalLookup, LocalLookup):
+class BeetsCollection(Collection, TrackStream, IDLookup):
     """A beets library collection."""
 
     db: BeetsDatabase
@@ -60,47 +60,30 @@ class BeetsCollection(Collection, TrackStream, GlobalLookup, LocalLookup):
             cols = table.columns.keys()
         return BeetsTrack(dict(zip(cols, row)))
 
-    # ------------------------------- Protocols ------------------------------ #
+    # --------------------------- IDLookup protocol ------------------------------ #
 
-    def find_by_global_ids(self, global_ids: GlobalTrackIDs) -> BeetsTrack | None:
-        isrc = global_ids.get("isrc")
-        if isrc is not None:
-            tracks = self.get_by_isrc(isrc)
+    def find_by_ids(self, ids: Iterable[TrackID]) -> BeetsTrack | None:
+        """Find a track by its identifiers.
 
-            match len(tracks):
-                case 0:
-                    pass
-                case 1:
+        Prioritizes BeetsTrackID, then FilePath, then ISRC.
+        """
+        for tid in ids:
+            if isinstance(tid, BeetsTrackID):
+                return self.get_by_id(tid.id)
+
+        for tid in ids:
+            if isinstance(tid, FilePath):
+                tracks = self.get_by_path(tid.path)
+                if tracks:
                     return tracks[0]
-                case _:
-                    log.warning(
-                        f"Multiple tracks found for ISRC {isrc}."
-                        " Returning the first one."
-                    )
+
+        for tid in ids:
+            if isinstance(tid, ISRC):
+                tracks = self.get_by_isrc(str(tid))
+                if tracks:
                     return tracks[0]
 
         return None
-
-    def find_by_local_ids(self, local_ids: LocalTrackIDs) -> BeetsTrack | None:
-        tracks: list[BeetsTrack] = []
-        if file_path := local_ids.get("file_path"):
-            tracks.extend(self.get_by_path(file_path))
-
-        if beets_id := local_ids.get("beets_id"):
-            track = self.get_by_id(beets_id)
-            if track:
-                tracks.append(track)
-
-        if len(tracks) == 0:
-            return None
-        elif len(tracks) == 1:
-            return tracks[0]
-        else:
-            log.warning(
-                f"Multiple tracks found for local IDs {local_ids}."
-                " Returning the first one."
-            )
-            return tracks[0]
 
     @property
     def tracks(self) -> Iterable[BeetsTrack]:

--- a/plistsync/services/beets/track.py
+++ b/plistsync/services/beets/track.py
@@ -1,11 +1,44 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, Self
+from dataclasses import dataclass
+from pathlib import Path, PurePath
+from typing import Any, ClassVar, Self
 
-from plistsync.core.track import LocalTrackIDs, TrackInfo
+from plistsync.core import Track, TrackID, TrackInfo
+from plistsync.core.ids import ISRC, FilePath, Scope
 
-from ...core import GlobalTrackIDs, Track
+
+@dataclass(frozen=True)
+class BeetsTrackID(TrackID):
+    """A Beets track identifier (database row ID)."""
+
+    # Only unique within a single beets database
+    scope: ClassVar[Scope] = Scope.LOCAL
+
+    id: int
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from serial format or raw ID."""
+        value = value.strip()
+        if value.lower().startswith("beets:"):
+            value = value[6:]
+        if not value.isdigit():
+            raise ValueError(f"Invalid Beets track id: {value!r}")
+        return cls(int(value))
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal representation for trackid on Beets."""
+        return f"beets:{self.id}"
+
+    def __str__(self) -> str:
+        """Compact display, understood by Beets API."""
+        return str(self.id)
+
+    def __int__(self) -> int:
+        """Compact display, understood by Beets API."""
+        return self.id
 
 
 class BeetsTrack(Track):
@@ -14,7 +47,6 @@ class BeetsTrack(Track):
     We might want to add more functionality in the future.
     """
 
-    # Option 1
     row: dict[str, Any]
 
     def __init__(self, row: dict) -> None:
@@ -74,32 +106,25 @@ class BeetsTrack(Track):
     # ------------------------------- Contracts ------------------------------ #
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        idents: GlobalTrackIDs = {}
-        # TODO: How to get tidal id from beets db?
+    def ids(self) -> frozenset[TrackID]:
+        idents: set[TrackID] = {BeetsTrackID(self.row["id"])}
+
+        # File path
+        path = self.path
+        if path is not None:
+            idents.add(FilePath(PurePath(path)))
+
+        # ISRC (already single-valued due to tracks_from_db_rows)
         isrc = self.row.get("isrc", None)
+        if isinstance(isrc, str) and isrc.strip():
+            try:
+                idents.add(ISRC(isrc.strip()))
+            except ValueError:
+                pass
 
-        if isinstance(isrc, str):
-            # If isrc is a string, we assume it is a single isrc
-            isrc = isrc.strip()
+        # TODO: beets support multiple identifiers, e.g. discogs, musicbrainz, etc.
 
-            if len(isrc) == 0:
-                isrc = None
-            else:
-                idents["isrc"] = isrc
-
-        return idents
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        """The local identifiers of this track.
-
-        This is the path to the file.
-        """
-        return LocalTrackIDs(
-            file_path=self.path,
-            beets_id=self.row["id"],
-        )
+        return frozenset(idents)
 
     @property
     def info(self) -> TrackInfo:

--- a/plistsync/services/local/collection.py
+++ b/plistsync/services/local/collection.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from plistsync.core import Collection, GlobalTrackIDs
+from plistsync.core import Collection, TrackID
+from plistsync.core.collection import IDLookup
 
-from .track import LocalTrack
+from .track import FileCache, LocalTrack
 
 
-class LocalCollection(Collection):
+class LocalCollection(Collection, IDLookup):
     """A a lazy collection of tracks from a file system.
 
     This collection does not load all tracks into memory at once. Instead it
@@ -17,8 +18,9 @@ class LocalCollection(Collection):
     """
 
     path: Path
+    _cache: FileCache | None
 
-    def __init__(self, path: Path | str):
+    def __init__(self, path: Path | str, cache: FileCache | None = None):
         """
         Create a new lazy collection of tracks from a file system path.
 
@@ -26,55 +28,39 @@ class LocalCollection(Collection):
         ----------
         path: Path | str
             The path to the directory containing the tracks.
+        cache: FileCache | None
+            Optional shared cache for file metadata to avoid repeated disk reads.
         """
 
         if isinstance(path, str):
             path = Path(path)
 
         self.path = path
+        self._cache = cache
 
         # Check if the path exists
         if not path.exists():
             raise FileNotFoundError(f"Path {path} does not exist.")
 
-    def find_by_identifiers(self, identifiers: GlobalTrackIDs) -> LocalTrack | None:
-        if len(identifiers) == 0:
+    def find_by_ids(self, ids: Iterable[TrackID]) -> LocalTrack | None:
+        """Find a track by its IDs."""
+        identifiers = frozenset(ids)
+        if not identifiers:
             return None
 
-        # Not too sure if this has any performance benefits but
-        # at least for the first read it should be faster than
-        # doing it single threaded
-        # Should be IO bound in most cases
-        # TODO: max workers should be configurable
         with ThreadPoolExecutor(max_workers=4) as executor:
 
-            def _get_track_identifiers(track: LocalTrack) -> GlobalTrackIDs:
-                return track.global_ids
+            def _get_track_ids(track: LocalTrack) -> frozenset[TrackID]:
+                return track.ids
 
-            futures = {
-                executor.submit(_get_track_identifiers, track): track for track in self
-            }
+            futures = {executor.submit(_get_track_ids, track): track for track in self}
 
         for future in as_completed(futures):
             track = futures[future]
-            track_ids: GlobalTrackIDs = future.result()
+            track_ids: frozenset[TrackID] = future.result()
 
-            # Search for each identifier in the tracks metadata
-            for key, value in identifiers.items():
-                if value is None or not isinstance(value, str):
-                    continue
-
-                found_value = track_ids.get(key)
-                if found_value is None or not isinstance(found_value, str):
-                    continue
-
-                # Casefold comparison is more robust than
-                # doing .lower() or .upper() as it handles
-                # more edge cases
-                value = value.casefold()
-                found_value = found_value.casefold()
-                if value == found_value:
-                    return track
+            if identifiers & track_ids:
+                return track
 
         return None
 
@@ -82,6 +68,4 @@ class LocalCollection(Collection):
         # Use rglob to recursively find all files
         for file_path in self.path.rglob("*"):
             if file_path.is_file():
-                potential_track = LocalTrack(file_path)
-                if potential_track is not None:
-                    yield potential_track
+                yield LocalTrack(file_path, cache=self._cache)

--- a/plistsync/services/local/track.py
+++ b/plistsync/services/local/track.py
@@ -161,7 +161,7 @@ class LocalTrack(Track):
                 if not raw:
                     continue
                 try:
-                    idents.add(ISRC.parse(raw))
+                    idents.add(ISRC(raw))
                 except ValueError:
                     log.debug(f"Invalid ISRC in file tags: {raw!r}")
 

--- a/plistsync/services/local/track.py
+++ b/plistsync/services/local/track.py
@@ -6,9 +6,10 @@ from typing import cast
 
 from tinytag import TinyTag
 
-from plistsync.core import Collection, GlobalTrackIDs, Track
+from plistsync.core import Collection, Track, TrackID
 from plistsync.core.collection import TrackStream
-from plistsync.core.track import LocalTrackIDs, TrackInfo
+from plistsync.core.ids import ISRC, FilePath
+from plistsync.core.track import TrackInfo
 
 from ...logger import log
 
@@ -26,6 +27,7 @@ class FileCache:
     TODO: what to have in cache when files are not available or cant be read?
     Empty dicts? None? Raise an error?
 
+    TODO: not sure if this is thread safe
     """
 
     _file_cache: dict[Path, TagDict] = {}
@@ -136,15 +138,13 @@ class LocalTrack(Track):
     # --------------------------------- Contracts -------------------------------- #
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        isrc_raw = self.tags.get("isrc", [])
-        isrc: str | None = None
+    def ids(self) -> frozenset[TrackID]:
+        idents: set[TrackID] = {FilePath(self.path)}
 
+        isrc_raw = self.tags.get("isrc", [])
         if not isinstance(isrc_raw, list):
-            # float, int does not make sense for isrc
             isrc_raw = [cast(str, isrc_raw)]
 
-        # Parse from array if necessary
         # Sometimes the isrc is a list of isrcs
         if len(isrc_raw) > 0:
             # For vorbis and other non id3 tags
@@ -156,30 +156,18 @@ class LocalTrack(Track):
             isrc_c: chain[str] = chain.from_iterable(
                 map(lambda x: x.split("\x00"), isrc_raw)
             )
-            isrc_raw = [x for x in isrc_c if x != ""]
+            for raw in isrc_c:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    idents.add(ISRC(raw))
+                except ValueError:
+                    log.debug(f"Invalid ISRC in file tags: {raw!r}")
 
-            if len(isrc_raw) > 1:
-                log.warning(f"Multiple ISRCs found for {self.path}: {isrc_raw}")
-            isrc = isrc_raw[0]
-
-        # Create typechecked identifiers dict
-        res = GlobalTrackIDs()
-        if isrc is not None:
-            res["isrc"] = isrc
-
-        # TODO: recover beets meta data tidal_id, spotify_id, etc.
-
-        return res
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        """The local identifiers of this track.
-
-        This is the path to the file.
-        """
-        return LocalTrackIDs(
-            file_path=self.path,
-        )
+        # TODO: In theory we could also add more ids from the tags,
+        #  e.g. MusicBrainz IDs...
+        return frozenset(idents)
 
     @property
     def info(self) -> TrackInfo:

--- a/plistsync/services/local/track.py
+++ b/plistsync/services/local/track.py
@@ -161,7 +161,7 @@ class LocalTrack(Track):
                 if not raw:
                     continue
                 try:
-                    idents.add(ISRC(raw))
+                    idents.add(ISRC.parse(raw))
                 except ValueError:
                     log.debug(f"Invalid ISRC in file tags: {raw!r}")
 

--- a/plistsync/services/plex/__init__.py
+++ b/plistsync/services/plex/__init__.py
@@ -9,7 +9,7 @@ check_imports(
 from . import api
 from .library import PlexLibrary
 from .playlist import PlexPlaylist, PlexPlaylistID
-from .track import PlexTrack
+from .track import PlexTrack, PlexTrackID
 
 
 class PlexService(Service):
@@ -25,5 +25,6 @@ __all__ = [
     "PlexPlaylistID",
     "PlexService",
     "PlexTrack",
+    "PlexTrackID",
     "api",
 ]

--- a/plistsync/services/plex/library.py
+++ b/plistsync/services/plex/library.py
@@ -5,23 +5,22 @@ from typing import overload
 
 from requests import HTTPError
 
-from plistsync.core import GlobalTrackIDs, Library, PathRewrite
-from plistsync.core.collection import GlobalLookup, LocalLookup, TrackStream
+from plistsync.core import Library, PathRewrite, TrackID
+from plistsync.core.collection import IDLookup, TrackStream
+from plistsync.core.ids import ISRC, FilePath
 from plistsync.core.playlist import PlaylistID
-from plistsync.core.track import LocalTrackIDs
 from plistsync.logger import log
 from plistsync.services.local.track import FileCache
 from plistsync.services.plex.playlist import PlexPlaylist, PlexPlaylistID
 
 from .api import PlexApi
-from .track import PlexTrack
+from .track import PlexTrack, PlexTrackID
 
 
 class PlexLibrary(
     Library[PlexTrack, PlexPlaylist],
     TrackStream[PlexTrack],
-    LocalLookup[PlexTrack],
-    GlobalLookup[PlexTrack],
+    IDLookup[PlexTrack],
 ):
     """A collection of all tracks in a Plex library section.
 
@@ -197,73 +196,42 @@ class PlexLibrary(
 
         self._fetched = True
 
-    # --------------------------- Lookup Protocols --------------------------- #
+    # --------------------------- IDLookup protocol ------------------------------ #
 
-    def find_by_global_ids(
+    def find_by_ids(
         self,
-        global_ids: GlobalTrackIDs,
+        ids: Iterable[TrackID],
         path_rewrite: PathRewrite | None = None,
         file_cache: FileCache | None = None,
-    ):
-        """Find a plex track via isrc.
+    ) -> PlexTrack | None:
+        """Find a track by its identifiers.
 
-        Note: Since isrc is not part of Plex's internal metadata, we have to do file
-        lookups. This will be slow, and requires you to mount the volume that holds
-        the actual tracks on your server.
-
-        Parameters
-        ----------
-        global_ids : GlobalTrackIDs
-            Needs to hold "isrc", otherwise no search is performed.
-        path_rewrite: PathRewrite
-            Rewrite rule to apply on the tracks, before metadata is looked up.
-            Set this if you run plistsync from another machine than your Plex server.
-            In the PathRewrite, "old" would be the Plex server, "new" the local mount.
-        file_cache: FileCache
-            Store the results of costly metadata lookups.
+        Prioritizes PlexTrackID, then FilePath, then ISRC (via file metadata).
         """
-        isrc = global_ids.get("isrc")
-        if isrc is None:
-            return None
-
-        for track in self.tracks:
-            local_track = track.get_local_track(
-                path_rewrite=path_rewrite,
-                file_cache=file_cache,
-            )
-            if local_track.global_ids.get("isrc") == isrc:
-                # TODO: PS 2026-02-13 this needs better abstraction.
-                # -> we want the isrc in the PlexTrack, too.
-                # We should have a library level cache.
-                # It can be auto-generated, preloaded, or gets filled as we fetch here.
-                track.global_ids["isrc"] = isrc
-                return track
-
-    def find_by_local_ids(
-        self, local_ids: LocalTrackIDs, path_rewrite: PathRewrite | None = None
-    ):
-        """Find a track by its plex ID (rating key) or file path.
-
-        Plex id is prioritized.
-
-        Parameters
-        ----------
-        local_ids : LocalTrackIDs
-            may contain plex_id and/pr file_path
-        path_rewrite: PathRewrite
-            Rewrite rule to apply on the tracks, before they are compared to local_ids.
-            Set this if you run plistsync from another machine than your Plex server.
-            In the PathRewrite, "old" would be the Plex server, "new" the local mount.
-        """
-
-        plex_id = local_ids.get("plex_id")
-        file_path = local_ids.get("file_path")
-
-        if path_rewrite is not None and file_path is not None:
-            file_path = path_rewrite.invert.apply(file_path)
+        # Extract known ID types
+        plex_id: str | None = None
+        file_paths: list[FilePath] = []
+        isrc: str | None = None
+        for tid in ids:
+            if isinstance(tid, PlexTrackID):
+                plex_id = str(tid)
+            elif isinstance(tid, FilePath):
+                file_paths.append(tid)
+            elif isinstance(tid, ISRC):
+                isrc = str(tid)
 
         for track in self.tracks:
             if plex_id and track.id == plex_id:
                 return track
-            if file_path and track.path and file_path == track.path:
-                return track
+            for fp in file_paths:
+                if track.path and fp.path == track.path:
+                    return track
+            if isrc:
+                local_track = track.get_local_track(
+                    path_rewrite=path_rewrite,
+                    file_cache=file_cache,
+                )
+                if local_track.isrc == isrc:
+                    return track
+
+        return None

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class PlexPlaylistID(PlaylistID):
-    service_name: ClassVar[str] = "plex"
     id: int
     # TODO: maybe we can add the server name to truely
     # make it unique

--- a/plistsync/services/plex/track.py
+++ b/plistsync/services/plex/track.py
@@ -1,12 +1,11 @@
-# see also
-# https://www.plexopedia.com/plex-media-server/api/library/music-albums-tracks/
-
 from __future__ import annotations
 
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import ClassVar, Self
 
-from plistsync.core import GlobalTrackIDs, PathRewrite, Track
-from plistsync.core.track import LocalTrackIDs, TrackInfo
+from plistsync.core import PathRewrite, Track, TrackID, TrackInfo
+from plistsync.core.ids import FilePath, Scope
 from plistsync.logger import log
 from plistsync.services.plex.api_types import (
     PlexApiPlaylistTrackResponse,
@@ -16,17 +15,48 @@ from plistsync.services.plex.api_types import (
 from ..local.track import FileCache, LocalTrack
 
 
+@dataclass(frozen=True)
+class PlexTrackID(TrackID):
+    """A Plex track identifier (rating key)."""
+
+    # Only unique within a single server
+    scope: ClassVar[Scope] = Scope.LOCAL
+
+    id: str
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from serial format or raw ID."""
+        value = value.strip()
+        if value.lower().startswith("plex:track:"):
+            value = value[11:]
+        if not value.isdigit():
+            raise ValueError(f"Invalid Plex track id: {value!r}")
+        return cls(value)
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal representation for trackid on Plex."""
+        return f"plex:track:{self.id}"
+
+    def __str__(self) -> str:
+        """Compact display, understood by Plex API."""
+        return self.id
+
+
 class PlexTrack(Track):
     """
     Track on a plex media server.
 
-    Ids are specific to one secdion (library) of one server instance.
+    Ids are specific to one section (library) of one server instance.
     (No global lookups)
 
     For the Plex Service, we currently do not distinguish Tracks and PlaylistTracks.
     The reason is that tracks in plex playlists only get one single extra piece
     of information (the playlist_item_id), but we have no info about when they were
     added to the playlist etc.
+
+    see also https://www.plexopedia.com/plex-media-server/api/library/music-albums-tracks/
     """
 
     data: PlexApiTrackResponse | PlexApiPlaylistTrackResponse
@@ -99,29 +129,17 @@ class PlexTrack(Track):
     # --------------------------------- Contracts -------------------------------- #
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        return GlobalTrackIDs()
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        lids = LocalTrackIDs()
-
-        # file path
+    def ids(self) -> frozenset[TrackID]:
+        idents: set[TrackID] = {PlexTrackID(self.id)}
         try:
             p_str = self.data.get("Media", [])[0].get("Part", [])[0].get("file")
-            if p_str is None:
-                raise IndexError("File attribute is None")
-            lids["file_path"] = Path(p_str)
+            if p_str is not None:
+                idents.add(FilePath(PurePath(p_str)))
         except IndexError:
             log.debug(
-                # Plex used to support remote tracks from Tidal.
                 "Could not get path from plex metadata, might be an old tidal track."
             )
-
-        # plex_id
-        lids["plex_id"] = self.id
-
-        return lids
+        return frozenset(idents)
 
     @property
     def info(self) -> TrackInfo:

--- a/plistsync/services/spotify/__init__.py
+++ b/plistsync/services/spotify/__init__.py
@@ -9,7 +9,7 @@ check_imports(
 from . import api
 from .library import SpotifyLibrary
 from .playlist import SpotifyPlaylist, SpotifyPlaylistID
-from .track import SpotifyPlaylistTrack, SpotifyTrack
+from .track import SpotifyPlaylistTrack, SpotifyTrack, SpotifyTrackID
 
 
 class SpotifyService(Service):
@@ -26,5 +26,6 @@ __all__ = [
     "SpotifyPlaylistTrack",
     "SpotifyService",
     "SpotifyTrack",
+    "SpotifyTrackID",
     "api",
 ]

--- a/plistsync/services/spotify/library.py
+++ b/plistsync/services/spotify/library.py
@@ -3,22 +3,23 @@ from typing import overload
 
 from requests import HTTPError
 
-from plistsync.core import GlobalTrackIDs
+from plistsync.core import TrackID
 from plistsync.core.collection import (
-    GlobalLookup,
+    IDLookup,
     Library,
 )
+from plistsync.core.ids import ISRC
 from plistsync.core.playlist import PlaylistID
 from plistsync.logger import log
 
 from .api import SpotifyApi
 from .playlist import SpotifyPlaylist, SpotifyPlaylistID
-from .track import SpotifyTrack
+from .track import SpotifyTrack, SpotifyTrackID
 
 
 class SpotifyLibrary(
     Library[SpotifyTrack, SpotifyPlaylist],
-    GlobalLookup[SpotifyTrack],
+    IDLookup[SpotifyTrack],
 ):
     """A collection representing the full spotify library.
 
@@ -134,63 +135,62 @@ class SpotifyLibrary(
 
         return pl
 
-    # --------------------------- GlobalLookup protocol -------------------------- #
+    # --------------------------- IDLookup protocol ------------------------------ #
 
-    def find_by_global_ids(self, global_ids: GlobalTrackIDs) -> SpotifyTrack | None:
-        """Find a track by its global ID.
+    def find_by_ids(self, ids: Iterable[TrackID]) -> SpotifyTrack | None:
+        """Find a track by its identifiers.
 
-        Prioritizes spotify_id, but also supports lookup by isrc if available.
+        Prioritizes Spotify ID lookups over ISRC lookups.
         """
-        if spotify_id := global_ids.get("spotify_id"):
+        for spotify_id in (tid for tid in ids if isinstance(tid, SpotifyTrackID)):
             try:
-                return SpotifyTrack(self.api.track.get(spotify_id))
+                return SpotifyTrack(self.api.track.get(str(spotify_id)))
             except HTTPError as e:
                 if e.response.status_code == 404:
                     log.debug(f"Could not find track by spotify ID {spotify_id}: {e}")
                 else:
                     raise
 
-        if isrc := global_ids.get("isrc"):
-            if data := self.api.track.get_by_isrc(isrc):
+        for isrc in (tid for tid in ids if isinstance(tid, ISRC)):
+            if data := self.api.track.get_by_isrc(str(isrc)):
                 return SpotifyTrack(data)
 
         return None
 
-    def find_many_by_global_ids(
-        self, global_ids_list: Iterable[GlobalTrackIDs]
+    def find_many_by_ids(
+        self, ids_iter: Iterable[Iterable[TrackID]]
     ) -> Iterable[SpotifyTrack | None]:
-        """Find many tracks by their global IDs.
+        """Find many tracks by their identifiers.
 
-        Prioritizes spotify_id, but also supports lookup by isrc if available.
-        Performs batch lookup for all tracks with spotify_id if possible.
+        Prioritizes Spotify ID lookups over ISRC lookups.
+        Performs batch lookup for all tracks with Spotify IDs if possible.
         """
         found_tracks: dict[int, SpotifyTrack] = {}
-        # avoid consuming this, we iterate twice.
-        global_ids_list = list(global_ids_list)
+        ids_list = [frozenset(gids) for gids in ids_iter]
 
-        # Get all with spotify id for batch lookup
-        idxes = []
+        # Spotify IDs batch lookup
+        idxes: list[int] = []
         spotify_ids: list[str] = []
-        for idx, gids in enumerate(global_ids_list):
-            if "spotify_id" in gids:
-                idxes.append(idx)
-                spotify_ids.append(gids["spotify_id"])
+        for idx, gids in enumerate(ids_list):
+            for tid in gids:
+                if isinstance(tid, SpotifyTrackID):
+                    idxes.append(idx)
+                    spotify_ids.append(str(tid))
+                    break
 
         if spotify_ids:
             tracks = self.api.track.get_many(spotify_ids)
-
             if len(spotify_ids) != len(tracks):
                 log.warning(
                     f"Expected {len(spotify_ids)} tracks but received {len(tracks)} "
                     "tracks as result from spotify batch lookup."
                 )
-
             for idx, track in zip(idxes, tracks):
                 found_tracks[idx] = SpotifyTrack(track)
 
         # Individual lookup for all missing tracks
-        for idx, gids in enumerate(global_ids_list):
+        for idx, gids in enumerate(ids_list):
             if idx in found_tracks:
                 yield found_tracks[idx]
             else:
-                yield self.find_by_global_ids(gids)
+                yield self.find_by_ids(gids)

--- a/plistsync/services/spotify/library.py
+++ b/plistsync/services/spotify/library.py
@@ -158,7 +158,7 @@ class SpotifyLibrary(
         return None
 
     def find_many_by_ids(
-        self, ids_iter: Iterable[Iterable[TrackID]]
+        self, track_ids_batch: Iterable[Iterable[TrackID]]
     ) -> Iterable[SpotifyTrack | None]:
         """Find many tracks by their identifiers.
 
@@ -166,13 +166,16 @@ class SpotifyLibrary(
         Performs batch lookup for all tracks with Spotify IDs if possible.
         """
         found_tracks: dict[int, SpotifyTrack] = {}
-        ids_list = [frozenset(gids) for gids in ids_iter]
+
+        # avoid consuming this, we iterate twice.
+        # inner: ids for one track, outer: tracks
+        ids_list = [frozenset(ids) for ids in track_ids_batch]
 
         # Spotify IDs batch lookup
         idxes: list[int] = []
         spotify_ids: list[str] = []
-        for idx, gids in enumerate(ids_list):
-            for tid in gids:
+        for idx, ids in enumerate(ids_list):
+            for tid in ids:
                 if isinstance(tid, SpotifyTrackID):
                     idxes.append(idx)
                     spotify_ids.append(str(tid))
@@ -189,8 +192,8 @@ class SpotifyLibrary(
                 found_tracks[idx] = SpotifyTrack(track)
 
         # Individual lookup for all missing tracks
-        for idx, gids in enumerate(ids_list):
+        for idx, ids in enumerate(ids_list):
             if idx in found_tracks:
                 yield found_tracks[idx]
             else:
-                yield self.find_by_ids(gids)
+                yield self.find_by_ids(ids)

--- a/plistsync/services/spotify/playlist.py
+++ b/plistsync/services/spotify/playlist.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class SpotifyPlaylistID(PlaylistID):
-    service_name: ClassVar[str] = "spotify"
     id: str
 
     @property

--- a/plistsync/services/spotify/track.py
+++ b/plistsync/services/spotify/track.py
@@ -27,13 +27,13 @@ class SpotifyTrackID(TrackID):
         """Parse from URL, URI, or raw ID."""
         value = value.strip()
         # URL (https://open.spotify.com/track/<id>)
-        if m := re.search(r"spotify\.com/track/([a-zA-Z0-9]+)", value):
+        if m := re.search(r"spotify\.com/track/([a-zA-Z0-9]{22})", value):
             return cls(m.group(1))
         # URI (spotify:track:<id>)
-        if m := re.match(r"spotify:track:([a-zA-Z0-9]+)$", value):
+        if m := re.match(r"spotify:(?:track:)?([a-zA-Z0-9]{22})$", value):
             return cls(m.group(1))
         # Plain ID
-        if re.fullmatch(r"[a-zA-Z0-9]+", value):
+        if re.fullmatch(r"[a-zA-Z0-9]{22}", value):
             return cls(value)
         raise ValueError(f"Invalid Spotify track id: {value!r}")
 

--- a/plistsync/services/spotify/track.py
+++ b/plistsync/services/spotify/track.py
@@ -1,10 +1,50 @@
-from plistsync.core import GlobalTrackIDs, Track
-from plistsync.core.track import LocalTrackIDs, TrackInfo
+import re
+from dataclasses import dataclass
+from typing import Self
+
+from plistsync.core import Track, TrackID, TrackInfo
+from plistsync.core.ids import ISRC
 from plistsync.services.spotify.api_types import (
     AddedBy,
     SpotifyApiPlaylistTrack,
     SpotifyApiTrackResponse,
 )
+
+
+@dataclass(frozen=True)
+class SpotifyTrackID(TrackID):
+    """A Spotify track identifier."""
+
+    id: str
+
+    @property
+    def url(self) -> str:
+        """Public web URL."""
+        return f"https://open.spotify.com/track/{self.id}"
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Parse from URL, URI, or raw ID."""
+        value = value.strip()
+        # URL (https://open.spotify.com/track/<id>)
+        if m := re.search(r"spotify\.com/track/([a-zA-Z0-9]+)", value):
+            return cls(m.group(1))
+        # URI (spotify:track:<id>)
+        if m := re.match(r"spotify:track:([a-zA-Z0-9]+)$", value):
+            return cls(m.group(1))
+        # Plain ID
+        if re.fullmatch(r"[a-zA-Z0-9]+", value):
+            return cls(value)
+        raise ValueError(f"Invalid Spotify track id: {value!r}")
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal representation for trackid on Spotify."""
+        return f"spotify:track:{self.id}"
+
+    def __str__(self) -> str:
+        """Compact display, understood by Spotify API."""
+        return self.id
 
 
 class SpotifyTrack(Track):
@@ -33,21 +73,12 @@ class SpotifyTrack(Track):
         )
 
     @property
-    def local_ids(self) -> LocalTrackIDs:
-        return LocalTrackIDs()
-
-    @property
-    def global_ids(self) -> GlobalTrackIDs:
-        idents: GlobalTrackIDs = {
-            "spotify_id": self.data["id"],
-        }
-
-        # In theory ean and upc are also available here
+    def ids(self) -> frozenset[TrackID]:
+        idents: set[TrackID] = {SpotifyTrackID(self.data["id"])}
         external_ids = self.data.get("external_ids", {})
         if isrc := external_ids.get("isrc"):
-            idents["isrc"] = isrc
-
-        return idents
+            idents.add(ISRC(isrc))
+        return frozenset(idents)
 
     @property
     def name(self) -> str:

--- a/plistsync/services/tidal/__init__.py
+++ b/plistsync/services/tidal/__init__.py
@@ -9,7 +9,7 @@ check_imports(
 from . import api
 from .library import TidalLibrary
 from .playlist import TidalPlaylist, TidalPlaylistID
-from .track import TidalPlaylistTrack, TidalTrack
+from .track import TidalPlaylistTrack, TidalTrack, TidalTrackID
 
 
 class TidalService(Service):
@@ -26,5 +26,6 @@ __all__ = [
     "TidalPlaylistTrack",
     "TidalService",
     "TidalTrack",
+    "TidalTrackID",
     "api",
 ]

--- a/plistsync/services/tidal/library.py
+++ b/plistsync/services/tidal/library.py
@@ -3,22 +3,23 @@ from typing import overload
 
 from requests import HTTPError
 
-from plistsync.core import GlobalTrackIDs
+from plistsync.core import TrackID
 from plistsync.core.collection import (
-    GlobalLookup,
+    IDLookup,
     Library,
 )
+from plistsync.core.ids import ISRC
 from plistsync.core.playlist import PlaylistID
 from plistsync.logger import log
 
 from .api import TidalApi
 from .playlist import TidalPlaylist, TidalPlaylistID
-from .track import TidalTrack
+from .track import TidalTrack, TidalTrackID
 
 
 class TidalLibrary(
     Library[TidalTrack, TidalPlaylist],
-    GlobalLookup[TidalTrack],
+    IDLookup[TidalTrack],
 ):
     """A collection of Tidal library items."""
 
@@ -132,39 +133,39 @@ class TidalLibrary(
                 return True
         return False
 
-    # --------------------------- GlobalLookup protocol -------------------------- #
+    # --------------------------- IDLookup protocol ------------------------------ #
 
-    def find_by_global_ids(self, global_ids: GlobalTrackIDs) -> TidalTrack | None:
-        """Find a track by its global IDs.
+    def find_by_ids(self, ids: Iterable[TrackID]) -> TidalTrack | None:
+        """Find a track by its identifiers.
 
-        Prioritizes isrc lookups over tidal_id lookups.
+        Prioritizes tidal ID lookups over ISRC lookups.
         """
-        return list(self.find_many_by_global_ids([global_ids]))[0]
+        return list(self.find_many_by_ids([ids]))[0]
 
-    def find_many_by_global_ids(
-        self, global_ids_list: Iterable[GlobalTrackIDs]
+    def find_many_by_ids(
+        self, ids_iter: Iterable[Iterable[TrackID]]
     ) -> Iterable[TidalTrack | None]:
-        """Find many tracks by their global IDs.
+        """Find many tracks by their identifiers.
 
-        Prioritizes isrc lookups over tidal_id lookups.
+        Prioritizes tidal ID lookups over ISRC lookups.
         """
-
         found_tracks: dict[int, TidalTrack] = {}
 
         # avoid consuming this, we iterate twice.
-        global_ids_list = list(global_ids_list)
+        ids_list = [frozenset(gids) for gids in ids_iter]
 
         # Tidal ids batch lookup
-        idxes = []
+        idxes: list[int] = []
         tidal_ids: list[str] = []
-        for idx, gids in enumerate(global_ids_list):
-            if "tidal_id" in gids:
-                idxes.append(idx)
-                tidal_ids.append(gids["tidal_id"])
+        for idx, gids in enumerate(ids_list):
+            for tid in gids:
+                if isinstance(tid, TidalTrackID):
+                    idxes.append(idx)
+                    tidal_ids.append(str(tid))
+                    break
 
         if tidal_ids:
             tracks, lookup = self.api.tracks.get_many(tidal_ids)
-
             for idx, track in zip(idxes, tracks):
                 if not track:
                     log.debug(f"Track with tidal_id '{tidal_ids[idx]}' not found")
@@ -174,21 +175,22 @@ class TidalLibrary(
         # ISRC batch lookup for remaining ids
         idxes = []
         isrcs: list[str] = []
-        for idx, gids in enumerate(global_ids_list):
+        for idx, gids in enumerate(ids_list):
             if idx in found_tracks:
                 continue
-            if "isrc" in gids:
-                idxes.append(idx)
-                isrcs.append(gids["isrc"])
+            for tid in gids:
+                if isinstance(tid, ISRC):
+                    idxes.append(idx)
+                    isrcs.append(str(tid))
+                    break
 
         if isrcs:
             tracks, lookup = self.api.tracks.get_many_by_isrc(isrcs)
-
             for idx, track in zip(idxes, tracks):
                 if not track:
                     log.debug(f"Track with isrc '{isrcs[idx]}' not found")
                 else:
                     found_tracks[idx] = TidalTrack(track, lookup)
 
-        for idx, gids in enumerate(global_ids_list):
+        for idx, gids in enumerate(ids_list):
             yield found_tracks.get(idx, None)

--- a/plistsync/services/tidal/library.py
+++ b/plistsync/services/tidal/library.py
@@ -143,7 +143,7 @@ class TidalLibrary(
         return list(self.find_many_by_ids([ids]))[0]
 
     def find_many_by_ids(
-        self, ids_iter: Iterable[Iterable[TrackID]]
+        self, track_ids_batch: Iterable[Iterable[TrackID]]
     ) -> Iterable[TidalTrack | None]:
         """Find many tracks by their identifiers.
 
@@ -152,13 +152,14 @@ class TidalLibrary(
         found_tracks: dict[int, TidalTrack] = {}
 
         # avoid consuming this, we iterate twice.
-        ids_list = [frozenset(gids) for gids in ids_iter]
+        # inner: ids for one track, outer: tracks
+        ids_list = [frozenset(ids) for ids in track_ids_batch]
 
         # Tidal ids batch lookup
         idxes: list[int] = []
         tidal_ids: list[str] = []
-        for idx, gids in enumerate(ids_list):
-            for tid in gids:
+        for idx, ids in enumerate(ids_list):
+            for tid in ids:
                 if isinstance(tid, TidalTrackID):
                     idxes.append(idx)
                     tidal_ids.append(str(tid))
@@ -175,10 +176,10 @@ class TidalLibrary(
         # ISRC batch lookup for remaining ids
         idxes = []
         isrcs: list[str] = []
-        for idx, gids in enumerate(ids_list):
+        for idx, ids in enumerate(ids_list):
             if idx in found_tracks:
                 continue
-            for tid in gids:
+            for tid in ids:
                 if isinstance(tid, ISRC):
                     idxes.append(idx)
                     isrcs.append(str(tid))
@@ -192,5 +193,5 @@ class TidalLibrary(
                 else:
                     found_tracks[idx] = TidalTrack(track, lookup)
 
-        for idx, gids in enumerate(ids_list):
+        for idx, ids in enumerate(ids_list):
             yield found_tracks.get(idx, None)

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, cast
 
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class TidalPlaylistID(PlaylistID):
-    service_name: ClassVar[str] = "tidal"
     id: str  # numeric playlist id
 
     @property

--- a/plistsync/services/tidal/track.py
+++ b/plistsync/services/tidal/track.py
@@ -1,16 +1,61 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime
 
-from plistsync.core import GlobalTrackIDs, Track
-from plistsync.core.track import LocalTrackIDs, TrackInfo
+from plistsync.core import Track, TrackID, TrackInfo
+from plistsync.core.ids import ISRC
 from plistsync.services.tidal.api_types import (
     PlaylistsItemsResourceIdentifierMeta,
     TrackResource,
 )
 
 from .api import LookupDict
+
+
+@dataclass(frozen=True)
+class TidalTrackID(TrackID):
+    """A Tidal track identifier.
+
+    This is a unique identifier for a track on Tidal.
+    """
+
+    id: str
+
+    @property
+    def url(self) -> str:
+        """Public web URL."""
+        return f"https://tidal.com/track/{self.id}"
+
+    @classmethod
+    def parse(cls, value: str) -> TidalTrackID:
+        """Parse from URL, URI, or raw id."""
+        value = value.strip()
+
+        # URL (https://listen.tidal.com/track/<id>)
+        if m := re.search(r"tidal\.com/(?:browse/)?track/([a-f0-9-]+)", value):
+            return cls(m.group(1))
+
+        # URI (tidal:track:<id>)
+        if m := re.match(r"tidal:track:([a-f0-9-]+)$", value):
+            return cls(m.group(1))
+
+        # Plain id (numeric)
+        if re.fullmatch(r"[a-f0-9-]+", value):
+            return cls(value)
+
+        raise ValueError(f"Invalid TIDAL track id: {value!r}")
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal representation for trackid on Tidal."""
+        return f"tidal:track:{self.id}"
+
+    def __str__(self) -> str:
+        """Compact display, understood by Tidal API."""
+        return self.id
 
 
 class TidalTrack(Track):
@@ -99,20 +144,15 @@ class TidalTrack(Track):
         )
 
     @property
-    def local_ids(self) -> LocalTrackIDs:
-        return LocalTrackIDs()
-
-    @property
-    def global_ids(self) -> GlobalTrackIDs:
-        idents: GlobalTrackIDs = {}
-
+    def ids(self) -> frozenset[TrackID]:
+        ids: set[TrackID] = set()
         if isrc := self.data.get("attributes", {}).get("isrc"):
-            idents["isrc"] = isrc
+            ids.add(ISRC(isrc))
 
         if tidal_id := self.data.get("id"):
-            idents["tidal_id"] = tidal_id
+            ids.add(TidalTrackID(tidal_id))
 
-        return idents
+        return frozenset(ids)
 
 
 class TidalPlaylistTrack(TidalTrack):

--- a/plistsync/services/traktor/library.py
+++ b/plistsync/services/traktor/library.py
@@ -10,9 +10,10 @@ from uuid import UUID
 from lxml import etree
 
 from plistsync.config import Config
-from plistsync.core.collection import Library, LocalLookup, TrackStream
+from plistsync.core import TrackID
+from plistsync.core.collection import IDLookup, Library, TrackStream
+from plistsync.core.ids import FilePath
 from plistsync.core.playlist import PlaylistID
-from plistsync.core.track import LocalTrackIDs
 from plistsync.logger import log
 
 from .path import NMLPath
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 class NMLLibrary(
     Library[NMLTrack, NMLPlaylist],
     TrackStream[NMLTrack],
-    LocalLookup[NMLTrack],
+    IDLookup[NMLTrack],
 ):
     """A Traktor NML Library.
 
@@ -214,16 +215,16 @@ class NMLLibrary(
         else:
             return None
 
-    # --------------------------- LocalLookup protocol --------------------------- #
+    # --------------------------- IDLookup protocol ------------------------------ #
 
-    def find_by_local_ids(self, local_ids: LocalTrackIDs) -> NMLTrack | None:
-        """Find a track by its local IDs.
+    def find_by_ids(self, ids: Iterable[TrackID]) -> NMLTrack | None:
+        """Find a track by its identifiers.
 
-        We only support lookup by path here.
+        Only FilePath lookups are supported.
         """
-        if file_path := local_ids.get("file_path"):
-            return self.find_by_traktor_path(NMLPath.from_path(file_path))
-
+        for tid in ids:
+            if isinstance(tid, FilePath):
+                return self.find_by_traktor_path(NMLPath.from_path(tid.path))
         return None
 
     def find_by_traktor_path(self, traktor_path: NMLPath) -> NMLTrack | None:

--- a/plistsync/services/traktor/playlist.py
+++ b/plistsync/services/traktor/playlist.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 from lxml.etree import Element, SubElement, _Element
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class NMLPlaylistID(PlaylistID):
-    service_name: ClassVar[str] = "traktor"
     id: UUID  # uuid
 
     @classmethod

--- a/plistsync/services/traktor/playlist.py
+++ b/plistsync/services/traktor/playlist.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 from lxml.etree import Element, SubElement, _Element
 
-from plistsync.core.collection import LocalLookup
+from plistsync.core import TrackID
+from plistsync.core.collection import IDLookup
+from plistsync.core.ids import FilePath
 from plistsync.core.playlist import (
     PlaylistID,
     PlaylistInfo,
     ServicePlaylist,
     Snapshot,
 )
-from plistsync.core.track import LocalTrackIDs
 from plistsync.logger import log
 
 from .path import NMLPath
@@ -76,7 +77,7 @@ class NMLPlaylistID(PlaylistID):
         return str(self.id.hex)  # Uses hex in internal repr
 
 
-class NMLPlaylist(ServicePlaylist[NMLPlaylistTrack], LocalLookup):
+class NMLPlaylist(ServicePlaylist[NMLPlaylistTrack], IDLookup):
     """A Traktor NML playlist collection.
 
     Traktor playlists use file paths as the identifiers.
@@ -216,22 +217,16 @@ class NMLPlaylist(ServicePlaylist[NMLPlaylistTrack], LocalLookup):
         self._tracks = [NMLPlaylistTrack(entry) for entry in entries]
         return self._tracks
 
-    # --------------------------- LocalLookup protocol --------------------------- #
+    # --------------------------- IDLookup protocol ------------------------------ #
 
-    def find_by_local_ids(self, local_ids: LocalTrackIDs) -> NMLPlaylistTrack | None:
-        """Find a track by its local IDs.
+    def find_by_ids(self, ids: Iterable[TrackID]) -> NMLPlaylistTrack | None:
+        """Find a track by its identifiers.
 
-        Note
-        -----
-        We only support lookup by file_path here. Other local ids are ignored.
-
-        Parameter
-        ---------
-        local_ids : LocalTrackIDs
+        Only FilePath lookups are supported.
         """
-        if file_path := local_ids.get("file_path"):
-            # If the file_path is set, we can use it to find the track
-            return self.find_by_traktor_path(NMLPath.from_path(file_path))
+        for tid in ids:
+            if isinstance(tid, FilePath):
+                return self.find_by_traktor_path(NMLPath.from_path(tid.path))
         return None
 
     def find_by_traktor_path(self, traktor_path: NMLPath) -> NMLPlaylistTrack | None:

--- a/plistsync/services/traktor/track.py
+++ b/plistsync/services/traktor/track.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 from lxml.etree import Element, SubElement
 
-from plistsync.core import GlobalTrackIDs, Track
-from plistsync.core.track import LocalTrackIDs, TrackInfo
+from plistsync.core import Track, TrackID, TrackInfo
+from plistsync.core.ids import FilePath
 
 from .path import NMLPath
 
@@ -88,17 +88,9 @@ class NMLTrack(Track):
     # ------------------------------- Contracts ------------------------------ #
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        """Sadly no unique identifier in NML files.
-        There exists an audio_id, but no idea how to use it or what it is.
-        """  # noqa: D205
-        return GlobalTrackIDs()
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        return LocalTrackIDs(
-            file_path=self.path,
-        )
+    def ids(self) -> frozenset[TrackID]:
+        # TODO: Check what audio_id is in the xml
+        return frozenset([FilePath(self.path)])
 
     @property
     def info(self) -> TrackInfo:
@@ -231,16 +223,8 @@ class NMLPlaylistTrack(Track):
     # ------------------------------- Contracts ------------------------------ #
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        """NMLPlaylistTrack does not have identifiers."""
-        return GlobalTrackIDs()
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        """NMLPlaylistTrack does not have identifiers."""
-        return LocalTrackIDs(
-            file_path=self.path,
-        )
+    def ids(self) -> frozenset[TrackID]:
+        return frozenset([FilePath(self.path)])
 
     @property
     def info(self) -> TrackInfo:

--- a/tests/abc/collection.py
+++ b/tests/abc/collection.py
@@ -1,13 +1,12 @@
 import pytest
 from typing import Any, ClassVar
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 
 from plistsync.core import Library, Track, Collection
 from plistsync.core.collection import (
-    GlobalLookup,
+    IDLookup,
     InfoLookup,
-    Iterable,
-    LocalLookup,
     TrackStream,
 )
 from plistsync.core.matching import Matches
@@ -40,27 +39,14 @@ class CollectionTestBase(ABC):
         """
         pass
 
-    def test_global_lookup(self):
-        """Test collections that implement GlobalLookup."""
+    def test_id_lookup(self):
+        """Test collections that implement IDLookup."""
         track = self.create_sample_track()
         for collection in self.create_collection():
-            if isinstance(collection, GlobalLookup):
-                found_track = collection.find_by_global_ids(track.global_ids)
-                # assumptions on the track returned by global id lookup
+            if isinstance(collection, IDLookup):
+                found_track = collection.find_by_ids(track.ids)
                 assert found_track is None or found_track == track, (
-                    "Global lookup should return the matching track or None"
-                )
-
-    def test_local_lookup(self):
-        """Test collections that implement LocalLookup."""
-        track = self.create_sample_track()
-        for collection in self.create_collection():
-            if isinstance(collection, LocalLookup):
-                found_track = collection.find_by_local_ids(track.local_ids)
-                # assumptions on the track returned by local id lookup
-                # TODO PS@semohr how do we want to decide that "they are equal"?
-                assert found_track is None or found_track.diff(track) == {}, (
-                    "Local lookup should return the matching track or None"
+                    "ID lookup should return the matching track or None"
                 )
 
     def test_info_lookup(self):

--- a/tests/abc/tracks.py
+++ b/tests/abc/tracks.py
@@ -21,13 +21,9 @@ class TestTrack(ABC):
         track = self.create_track()
         assert isinstance(track.info, dict), "info should be a dict"
 
-    def test_property_global_ids(self):
+    def test_property_ids(self):
         track = self.create_track()
-        assert isinstance(track.global_ids, dict), "global_ids should be a dict"
-
-    def test_property_local_ids(self):
-        track = self.create_track()
-        assert isinstance(track.local_ids, dict), "local_ids should be a dict"
+        assert isinstance(track.ids, frozenset), "ids should be a frozenset"
 
     # -------------------------- Derived from contracts -------------------------- #
 

--- a/tests/core/mock_collections.py
+++ b/tests/core/mock_collections.py
@@ -1,49 +1,31 @@
 from collections.abc import Iterable, Iterator
-from plistsync.core.track import TrackInfo, GlobalTrackIDs, LocalTrackIDs
-from .mock_track import MockTrack
 
+from plistsync.core import TrackID
 from plistsync.core.collection import (
     Collection,
-    GlobalLookup,
-    LocalLookup,
+    IDLookup,
     InfoLookup,
     TrackStream,
 )
+from plistsync.core.track import TrackInfo
+
+from .mock_track import MockTrack
 
 
-class MockGlobalLookupCollection(Collection, GlobalLookup):
-    """Mock collection with global lookup capability."""
-
-    def __init__(self, tracks: list[MockTrack] | None = None):
-        self.tracks = tracks or []
-        self._tracks_by_global_id = {
-            global_id: track
-            for track in self.tracks
-            for global_id in track.global_ids.values()
-        }
-
-    def find_by_global_ids(self, global_ids: GlobalTrackIDs) -> MockTrack | None:
-        for global_id in global_ids.values():
-            if global_id in self._tracks_by_global_id:
-                return self._tracks_by_global_id[global_id]
-        return None
-
-
-class MockLocalLookupCollection(Collection, LocalLookup):
-    """Mock collection with local lookup capability."""
+class MockIDLookupCollection(Collection, IDLookup):
+    """Mock collection with ID lookup capability."""
 
     def __init__(self, tracks: list[MockTrack] | None = None):
         self.tracks = tracks or []
-        self._tracks_by_local_id = {
-            local_id: track
-            for track in self.tracks
-            for local_id in track.local_ids.values()
-        }
+        self._tracks_by_id: dict[TrackID, MockTrack] = {}
+        for track in self.tracks:
+            for tid in track.ids:
+                self._tracks_by_id[tid] = track
 
-    def find_by_local_ids(self, local_ids: LocalTrackIDs) -> MockTrack | None:
-        for local_id in local_ids.values():
-            if local_id in self._tracks_by_local_id:
-                return self._tracks_by_local_id[local_id]
+    def find_by_ids(self, ids: Iterable[TrackID]) -> MockTrack | None:
+        for tid in ids:
+            if tid in self._tracks_by_id:
+                return self._tracks_by_id[tid]
         return None
 
 
@@ -70,34 +52,20 @@ class MockTrackStreamCollection(Collection, TrackStream):
         yield from self._tracks
 
 
-class MockFullCapabilityCollection(
-    Collection, GlobalLookup, LocalLookup, InfoLookup, TrackStream
-):
+class MockFullCapabilityCollection(Collection, IDLookup, InfoLookup, TrackStream):
     """Mock collection with all capabilities."""
 
     def __init__(self, tracks: list[MockTrack] | None = None):
         self._tracks = tracks or []
-        self._tracks_by_global_id = {
-            global_id: track
-            for track in self._tracks
-            for global_id in track.global_ids.values()
-        }
-        self._tracks_by_local_id = {
-            local_id: track
-            for track in self._tracks
-            for local_id in track.local_ids.values()
-        }
+        self._tracks_by_id: dict[TrackID, MockTrack] = {}
+        for track in self._tracks:
+            for tid in track.ids:
+                self._tracks_by_id[tid] = track
 
-    def find_by_global_ids(self, global_ids: GlobalTrackIDs) -> MockTrack | None:
-        for global_id in global_ids.values():
-            if global_id in self._tracks_by_global_id:
-                return self._tracks_by_global_id[global_id]
-        return None
-
-    def find_by_local_ids(self, local_ids: LocalTrackIDs) -> MockTrack | None:
-        for local_id in local_ids.values():
-            if local_id in self._tracks_by_local_id:
-                return self._tracks_by_local_id[local_id]
+    def find_by_ids(self, ids: Iterable[TrackID]) -> MockTrack | None:
+        for tid in ids:
+            if tid in self._tracks_by_id:
+                return self._tracks_by_id[tid]
         return None
 
     def find_by_info(self, info: TrackInfo) -> Iterator[MockTrack]:

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -75,4 +75,6 @@ class MockMultiRequestServicePlaylist(
 
     @staticmethod
     def _track_key(track) -> str:
-        return track.global_ids.get("isrc", str(random.randbytes(10)))
+        for tid in track.ids:
+            return tid.serial
+        return str(random.randbytes(10))

--- a/tests/core/mock_track.py
+++ b/tests/core/mock_track.py
@@ -1,4 +1,5 @@
-from plistsync.core.track import Track, TrackInfo, GlobalTrackIDs, LocalTrackIDs
+from plistsync.core import TrackID
+from plistsync.core.track import Track, TrackInfo
 
 
 class MockTrack(Track):
@@ -9,14 +10,12 @@ class MockTrack(Track):
         title: str = "Test Track",
         artists: list[str] | None = None,
         albums: list[str] | None = None,
-        global_ids: GlobalTrackIDs | None = None,
-        local_ids: LocalTrackIDs | None = None,
+        ids: set[TrackID] | None = None,
     ):
         self._title = title
         self._artists = artists or []
         self._albums = albums or []
-        self._global_ids = global_ids or {}
-        self._local_ids = local_ids or {}
+        self._ids = ids or set()
         self._info = TrackInfo(
             **{
                 "title": title,
@@ -30,9 +29,5 @@ class MockTrack(Track):
         return self._info
 
     @property
-    def global_ids(self) -> GlobalTrackIDs:
-        return self._global_ids
-
-    @property
-    def local_ids(self) -> LocalTrackIDs:
-        return self._local_ids
+    def ids(self) -> frozenset[TrackID]:
+        return frozenset(self._ids)

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -3,20 +3,18 @@
 import pytest
 
 from plistsync.core.collection import (
-    GlobalLookup,
-    LocalLookup,
+    IDLookup,
     InfoLookup,
     TrackStream,
 )
+from plistsync.core.ids import ISRC
 
 from .mock_collections import (
-    MockGlobalLookupCollection,
-    MockLocalLookupCollection,
+    MockIDLookupCollection,
     MockInfoLookupCollection,
     MockTrackStreamCollection,
     MockFullCapabilityCollection,
 )
-
 from .mock_track import MockTrack
 
 
@@ -26,20 +24,19 @@ class TestProtocolRuntimeChecking:
     @pytest.mark.parametrize(
         "collection_type, check",
         [
-            (MockGlobalLookupCollection, GlobalLookup),
-            (MockLocalLookupCollection, LocalLookup),
+            (MockIDLookupCollection, IDLookup),
             (MockInfoLookupCollection, InfoLookup),
             (MockTrackStreamCollection, TrackStream),
             (
                 MockFullCapabilityCollection,
-                (GlobalLookup, LocalLookup, InfoLookup, TrackStream),
+                (IDLookup, InfoLookup, TrackStream),
             ),
         ],
     )
-    def test_runtime_checkable_global_lookup(self, collection_type, check):
-        """Test runtime checking for GlobalLookup protocol."""
+    def test_runtime_checkable(self, collection_type, check):
+        """Test runtime checking for protocols."""
         col = collection_type([])
-        for ins in [GlobalLookup, LocalLookup, InfoLookup, TrackStream]:
+        for ins in [IDLookup, InfoLookup, TrackStream]:
             if (isinstance(check, tuple) and (ins in check)) or check == ins:
                 assert isinstance(col, ins)
             else:
@@ -49,24 +46,22 @@ class TestProtocolRuntimeChecking:
 class TestMatchingInCollections:
     """Test matching functionality in collections."""
 
-    def test_find_by_global_id(self):
-        """Test that NotImplementedError is raised for unimplemented method."""
-
+    def test_find_by_ids(self):
+        """Test find_by_ids for exact ID matches."""
         col = MockFullCapabilityCollection(
             [
-                MockTrack("1", global_ids={"isrc": "A"}),
-                MockTrack("2", global_ids={"isrc": "B"}),
+                MockTrack("1", ids={ISRC("A")}),
+                MockTrack("2", ids={ISRC("B")}),
             ]
         )
-
-        found = col.find_by_global_ids({"isrc": "A"})
+        found = col.find_by_ids({ISRC("A")})
         assert found is not None and found.title == "1"
 
-        found_many = col.find_many_by_global_ids(
+        found_many = col.find_many_by_ids(
             [
-                {"isrc": "A"},
-                {"isrc": "B"},
-                {"isrc": "C"},
+                {ISRC("A")},
+                {ISRC("B")},
+                {ISRC("C")},
             ]
         )
         tracks = list(filter(None, found_many))
@@ -83,25 +78,23 @@ class TestMatchingInCollections:
     @pytest.mark.parametrize(
         "collection_type",
         [
-            MockGlobalLookupCollection,
+            MockIDLookupCollection,
             MockTrackStreamCollection,
             MockFullCapabilityCollection,
         ],
     )
-    def test_match_global(self, skip_after_local, skip_after_fuzzy, collection_type):
-        """Test global matching in the collection.
-        E.g. by ISRC.
-        """
+    def test_match_id_lookup(self, skip_after_local, skip_after_fuzzy, collection_type):
+        """Test ID-based matching in the collection."""
         track = MockTrack(
             title="Test Track",
-            global_ids={"isrc": "id"},
+            ids={ISRC("id")},
         )
         col = collection_type([track])
 
         found = col.match(
             MockTrack(
                 title="FOOO",
-                global_ids={"isrc": "id"},
+                ids={ISRC("id")},
             ),
             skip_after_local_match=skip_after_local,
             skip_after_perfect_fuzzy_match=skip_after_fuzzy,
@@ -120,30 +113,26 @@ class TestMatchingInCollections:
     @pytest.mark.parametrize(
         "collection_type",
         [
-            MockLocalLookupCollection,
+            MockIDLookupCollection,
             MockTrackStreamCollection,
             MockFullCapabilityCollection,
         ],
     )
-    def test_match_local(self, skip_after_local, skip_after_fuzzy, collection_type):
-        """Test local matching in the collection.
-        E.g. by Plex local ID.
-        """
-        track = MockTrack(
-            title="Test Track",
-            local_ids={"plex_id": "local-id"},
-        )
-        col = collection_type([track])
+    def test_match_id_lookup_no_match(
+        self, skip_after_local, skip_after_fuzzy, collection_type
+    ):
+        """Test ID-based matching when no ID matches."""
+        col = collection_type([MockTrack("1", ids={ISRC("A")})])
 
         found = col.match(
             MockTrack(
-                local_ids={"plex_id": "local-id"},
+                title="Track 2",
+                ids={ISRC("B")},
             ),
             skip_after_local_match=skip_after_local,
             skip_after_perfect_fuzzy_match=skip_after_fuzzy,
         ).best_match
-        assert found is not None
-        assert found == track
+        assert found is None
 
     @pytest.mark.parametrize(
         "skip_after_local, skip_after_fuzzy",
@@ -162,20 +151,12 @@ class TestMatchingInCollections:
         ],
     )
     def test_match_info(self, skip_after_local, skip_after_fuzzy, collection_type):
-        """Test info matching in the collection.
-        E.g. by title.
-        """
-        track = MockTrack(
-            title="Unique Title",
-        )
+        """Test info matching in the collection."""
+        track = MockTrack(title="Unique Title")
         col = collection_type([track])
 
         found = col.match(
-            MockTrack(
-                title="Unique Title",
-                global_ids={"isrc": "non-matching-id"},
-                local_ids={"plex_id": "non-matching-local-id"},
-            ),
+            MockTrack(title="Unique Title"),
             skip_after_local_match=skip_after_local,
             skip_after_perfect_fuzzy_match=skip_after_fuzzy,
         ).best_match
@@ -186,15 +167,12 @@ class TestMatchingInCollections:
         """Test that cutoff works in matching."""
         track = MockTrack(
             title="Test Track",
-            global_ids={"isrc": "id"},
+            ids={ISRC("id")},
         )
         col = MockTrackStreamCollection([track])
 
-        # Matching with high cutoff should yield no results
         matches = col.match(
-            MockTrack(
-                title="Test",
-            ),
+            MockTrack(title="Test"),
             cutoff=1.0,
         )
         assert matches.best_match is None

--- a/tests/core/test_ids.py
+++ b/tests/core/test_ids.py
@@ -1,13 +1,11 @@
 import pytest
 from pathlib import PurePath
 
-from plistsync.core.ids import TrackID, ISRC, FilePath
+from plistsync.core.ids import TrackID, PlaylistID, ISRC, FilePath
 
 
 class TestISRC:
     """Tests for the ISRC identifier."""
-
-    # -- parse ----------------------------------------------------------------
 
     @pytest.mark.parametrize(
         "input_value, expected_id",
@@ -16,6 +14,7 @@ class TestISRC:
             ("isrc:USRC17607839", "USRC17607839"),
             ("ISRC:USRC17607839", "USRC17607839"),
             ("usrc17607839", "USRC17607839"),
+            ("US-RC1-76-07839", "USRC17607839"),
             ("  USRC17607839  ", "USRC17607839"),
             ("  isrc:USRC17607839  ", "USRC17607839"),
         ],
@@ -39,17 +38,11 @@ class TestISRC:
         with pytest.raises(ValueError):
             ISRC.parse(bad_input)
 
-    # -- serial ----------------------------------------------------------------
-
     def test_serial(self):
         assert ISRC("USRC17607839").serial == "isrc:USRC17607839"
 
-    # -- str -------------------------------------------------------------------
-
     def test_str(self):
         assert str(ISRC("USRC17607839")) == "USRC17607839"
-
-    # -- dataclass behaviour ---------------------------------------------------
 
     def test_equality(self):
         a = ISRC("USRC17607839")
@@ -64,12 +57,19 @@ class TestISRC:
         with pytest.raises(Exception):
             isrc.id = "GBARL2000789"  # type: ignore[misc]
 
-    def test_repr(self):
-        r = repr(ISRC("USRC17607839"))
-        assert "ISRC" in r
-        assert "USRC17607839" in r
+    @pytest.mark.parametrize(
+        "raw, expected_id",
+        [
+            ("usrc17607839", "USRC17607839"),
+            ("US-RC1-76-07839", "USRC17607839"),
+            ("us-rc1-76-07839", "USRC17607839"),
+        ],
+    )
+    def test_init_normalises(self, raw, expected_id):
+        assert ISRC(raw).id == expected_id
 
-    # -- subclass contract -----------------------------------------------------
+    def test_repr(self):
+        assert repr(ISRC("USRC17607839")) == "ISRC(id='USRC17607839')"
 
     def test_is_track_id(self):
         assert issubclass(ISRC, TrackID)
@@ -77,8 +77,6 @@ class TestISRC:
 
 class TestFilePath:
     """Tests for the FilePath identifier."""
-
-    # -- parse ----------------------------------------------------------------
 
     @pytest.mark.parametrize(
         "input_value, expected_path",
@@ -92,8 +90,6 @@ class TestFilePath:
     )
     def test_parse(self, input_value, expected_path):
         assert FilePath.parse(input_value).path == expected_path
-
-    # -- serial ----------------------------------------------------------------
 
     @pytest.mark.parametrize(
         "path, expected_serial",
@@ -109,8 +105,6 @@ class TestFilePath:
         fp = FilePath.parse("/home/user/music/song.flac")
         assert FilePath.parse(fp.serial) == fp
 
-    # -- str -------------------------------------------------------------------
-
     @pytest.mark.parametrize(
         "path, expected_str",
         [
@@ -120,8 +114,6 @@ class TestFilePath:
     )
     def test_str(self, path, expected_str):
         assert str(FilePath(path)) == expected_str
-
-    # -- dataclass behaviour ---------------------------------------------------
 
     def test_equality(self):
         a = FilePath(PurePath("/home/user/music/song.flac"))
@@ -141,7 +133,33 @@ class TestFilePath:
         assert "FilePath" in r
         assert "song.flac" in r
 
-    # -- subclass contract -----------------------------------------------------
-
     def test_is_track_id(self):
         assert issubclass(FilePath, TrackID)
+
+
+class TestTrackIDRepr:
+    """The ABC __repr__ is only used by non-dataclass subclasses."""
+
+    def test_track_id_repr(self):
+        class _Minimal(TrackID):
+            @classmethod
+            def parse(cls, value: str):
+                return cls()
+
+            @property
+            def serial(self) -> str:
+                return "test:123"
+
+        assert repr(_Minimal()) == "_Minimal(serial='test:123')"
+
+    def test_playlist_id_repr(self):
+        class _Minimal(PlaylistID):
+            @classmethod
+            def parse(cls, value: str):
+                return cls()
+
+            @property
+            def serial(self) -> str:
+                return "test:456"
+
+        assert repr(_Minimal()) == "_Minimal(serial='test:456')"

--- a/tests/core/test_ids.py
+++ b/tests/core/test_ids.py
@@ -1,0 +1,147 @@
+import pytest
+from pathlib import PurePath
+
+from plistsync.core.ids import TrackID, ISRC, FilePath
+
+
+class TestISRC:
+    """Tests for the ISRC identifier."""
+
+    # -- parse ----------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "input_value, expected_id",
+        [
+            ("USRC17607839", "USRC17607839"),
+            ("isrc:USRC17607839", "USRC17607839"),
+            ("ISRC:USRC17607839", "USRC17607839"),
+            ("usrc17607839", "USRC17607839"),
+            ("  USRC17607839  ", "USRC17607839"),
+            ("  isrc:USRC17607839  ", "USRC17607839"),
+        ],
+    )
+    def test_parse(self, input_value, expected_id):
+        isrc = ISRC.parse(input_value)
+        assert isrc.id == expected_id
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            "bad",
+            "USR",  # too short
+            "USRC176078399",  # too long (13 chars)
+            "USRC1760783",  # too short (11 chars)
+            "12RC17607839",  # country code must be letters
+            "USRC1760783A",  # last 7 must be digits
+        ],
+    )
+    def test_parse_invalid_raises(self, bad_input):
+        with pytest.raises(ValueError):
+            ISRC.parse(bad_input)
+
+    # -- serial ----------------------------------------------------------------
+
+    def test_serial(self):
+        assert ISRC("USRC17607839").serial == "isrc:USRC17607839"
+
+    # -- str -------------------------------------------------------------------
+
+    def test_str(self):
+        assert str(ISRC("USRC17607839")) == "USRC17607839"
+
+    # -- dataclass behaviour ---------------------------------------------------
+
+    def test_equality(self):
+        a = ISRC("USRC17607839")
+        b = ISRC("USRC17607839")
+        c = ISRC("GBARL2000789")
+        assert a == b
+        assert a != c
+        assert hash(a) == hash(b)
+
+    def test_immutable(self):
+        isrc = ISRC("USRC17607839")
+        with pytest.raises(Exception):
+            isrc.id = "GBARL2000789"  # type: ignore[misc]
+
+    def test_repr(self):
+        r = repr(ISRC("USRC17607839"))
+        assert "ISRC" in r
+        assert "USRC17607839" in r
+
+    # -- subclass contract -----------------------------------------------------
+
+    def test_is_track_id(self):
+        assert issubclass(ISRC, TrackID)
+
+
+class TestFilePath:
+    """Tests for the FilePath identifier."""
+
+    # -- parse ----------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "input_value, expected_path",
+        [
+            ("/home/user/music/song.flac", PurePath("/home/user/music/song.flac")),
+            ("file:/home/user/music/song.flac", PurePath("/home/user/music/song.flac")),
+            ("FILE:/home/user/music/song.flac", PurePath("/home/user/music/song.flac")),
+            ("  /home/user/music/song.flac  ", PurePath("/home/user/music/song.flac")),
+            ("music/song.flac", PurePath("music/song.flac")),
+        ],
+    )
+    def test_parse(self, input_value, expected_path):
+        assert FilePath.parse(input_value).path == expected_path
+
+    # -- serial ----------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "path, expected_serial",
+        [
+            (PurePath("/home/user/music/song.flac"), "file:/home/user/music/song.flac"),
+            (PurePath("music/song.flac"), "file:music/song.flac"),
+        ],
+    )
+    def test_serial(self, path, expected_serial):
+        assert FilePath(path).serial == expected_serial
+
+    def test_serial_roundtrip(self):
+        fp = FilePath.parse("/home/user/music/song.flac")
+        assert FilePath.parse(fp.serial) == fp
+
+    # -- str -------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "path, expected_str",
+        [
+            (PurePath("/home/user/music/song.flac"), "/home/user/music/song.flac"),
+            (PurePath("music/song.flac"), "music/song.flac"),
+        ],
+    )
+    def test_str(self, path, expected_str):
+        assert str(FilePath(path)) == expected_str
+
+    # -- dataclass behaviour ---------------------------------------------------
+
+    def test_equality(self):
+        a = FilePath(PurePath("/home/user/music/song.flac"))
+        b = FilePath(PurePath("/home/user/music/song.flac"))
+        c = FilePath(PurePath("/other/path.mp3"))
+        assert a == b
+        assert a != c
+        assert hash(a) == hash(b)
+
+    def test_immutable(self):
+        fp = FilePath(PurePath("/home/user/music/song.flac"))
+        with pytest.raises(Exception):
+            fp.path = PurePath("/other")  # type: ignore[misc]
+
+    def test_repr(self):
+        r = repr(FilePath(PurePath("/home/user/music/song.flac")))
+        assert "FilePath" in r
+        assert "song.flac" in r
+
+    # -- subclass contract -----------------------------------------------------
+
+    def test_is_track_id(self):
+        assert issubclass(FilePath, TrackID)

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -1,6 +1,7 @@
 from typing import Any
 from unittest.mock import ANY, Mock
 import pytest
+from plistsync.core.ids import ISRC
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
     OfflinePlaylist,
@@ -24,7 +25,7 @@ class TestOfflinePlaylist(TestPlaylistBase):
             info=PlaylistInfo(name=name, description="description"),
             id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
             tracks=[
-                OfflineTrack(info={"title": f"Track {i}"}, global_ids={"isrc": str(i)})
+                OfflineTrack(info={"title": f"Track {i}"}, ids={ISRC(str(i))})
                 for i in range(n_tracks)
             ],
         )
@@ -56,7 +57,7 @@ class TestMockServicePlaylist(TestServicePlaylistBase):
         return MockServicePlaylist(
             info=PlaylistInfo(name=name, description="description"),
             id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
-            tracks=[MockTrack(global_ids={"isrc": str(i)}) for i in range(n_tracks)],
+            tracks=[MockTrack(ids={ISRC(str(i))}) for i in range(n_tracks)],
         )
 
 
@@ -65,7 +66,7 @@ class TestMockMultiRequestServicePlaylist(TestMultiRequestServicePlaylistBase):
         return MockMultiRequestServicePlaylist(
             info=PlaylistInfo(name=name, description="description"),
             id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
-            tracks=[MockTrack(global_ids={"isrc": str(i)}) for i in range(n_tracks)],
+            tracks=[MockTrack(ids={ISRC(str(i))}) for i in range(n_tracks)],
         )
 
     def test_default_remote_move_track(self, playlist: MultiRequestServicePlaylist):

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -1,7 +1,8 @@
 import pytest
 from pathlib import PurePath
 
-from plistsync.core.track import OfflineTrack, Track, GlobalTrackIDs, LocalTrackIDs
+from plistsync.core.ids import FilePath, ISRC
+from plistsync.core.track import OfflineTrack, Track
 from tests.abc.tracks import TestTrack
 from .mock_track import MockTrack
 
@@ -17,7 +18,6 @@ class TestMockTrack(TestTrack):
         with pytest.raises(TypeError):
             Track()  # type: ignore
 
-    # TODO: The following tests need a bit of alignment with the base 'TestTrack'
     def test_property_track_info(self):
         """Test the info property returns correct TrackInfo."""
         track = MockTrack(
@@ -25,37 +25,22 @@ class TestMockTrack(TestTrack):
             artists=["Artist 1", "Artist 2"],
             albums=["Album 1"],
         )
-
         info = track.info
         assert isinstance(info, dict)
         assert info.get("title") == "Test Title"
         assert info.get("artists") == ["Artist 1", "Artist 2"]
         assert info.get("albums") == ["Album 1"]
 
-    def test_global_ids_property(self):
-        """Test the global_ids property."""
-        global_ids: GlobalTrackIDs = {
-            "tidal_id": "12345",
-            "isrc": "USRC17607839",
-            "spotify_id": "spotify:track:abc123",
-        }
-        track = MockTrack(global_ids=global_ids)
-        assert track.global_ids.get("tidal_id") == "12345"
-        assert track.global_ids.get("isrc") == "USRC17607839"
-        assert track.global_ids.get("spotify_id") == "spotify:track:abc123"
-
-    def test_local_ids_property(self):
-        """Test the local_ids property."""
-        local_ids: LocalTrackIDs = {
-            "file_path": PurePath("/music/song.mp3"),
-            "beets_id": 42,
-            "plex_id": "plex://library/123",
-        }
-        track = MockTrack(local_ids=local_ids)
-
-        assert track.local_ids.get("file_path") == PurePath("/music/song.mp3")
-        assert track.local_ids.get("beets_id") == 42
-        assert track.local_ids.get("plex_id") == "plex://library/123"
+    def test_ids_property(self):
+        """Test the ids property."""
+        ids = {ISRC("USRC17607839"), FilePath(PurePath("/music/song.mp3"))}
+        track = MockTrack(ids=ids)
+        assert len(track.ids) == 2
+        assert any(isinstance(t, ISRC) and t.id == "USRC17607839" for t in track.ids)
+        assert any(
+            isinstance(t, FilePath) and t.path == PurePath("/music/song.mp3")
+            for t in track.ids
+        )
 
     def test_convenience_getters(self):
         """Test the convenience getter properties."""
@@ -63,10 +48,8 @@ class TestMockTrack(TestTrack):
             title="My Song",
             artists=["Main Artist", "Feat Artist"],
             albums=["Album A", "Album B"],
-            global_ids={"isrc": "USRC12345678"},
-            local_ids={"file_path": PurePath("/path/to/song.mp3")},
+            ids={ISRC("USRC12345678"), FilePath(PurePath("/path/to/song.mp3"))},
         )
-
         assert track.title == "My Song"
         assert track.artists == ["Main Artist", "Feat Artist"]
         assert track.albums == ["Album A", "Album B"]
@@ -76,8 +59,7 @@ class TestMockTrack(TestTrack):
 
     def test_convenience_getters_with_missing_data(self):
         """Test convenience getters when data is missing."""
-        track = MockTrack(title="", artists=[], albums=[], global_ids={}, local_ids={})
-
+        track = MockTrack(title="", artists=[], albums=[], ids=set())
         assert track.title == ""
         assert track.artists == []
         assert track.albums == []
@@ -92,41 +74,36 @@ class TestMockTrack(TestTrack):
             artists=["Artist 1", "Artist 2", "Artist 3"],
             albums=["Original Album", "Greatest Hits", "Remix Album"],
         )
-
         assert len(track.artists) == 3
         assert track.artists[0] == "Artist 1"
         assert track.artists[1] == "Artist 2"
         assert track.artists[2] == "Artist 3"
-
         assert len(track.albums) == 3
         assert "Greatest Hits" in track.albums
         assert track.primary_artist == "Artist 1"
 
     @pytest.mark.parametrize(
-        "local_ids,expected",
+        "ids,expected",
         [
-            (
-                {"file_path": PurePath("/music/track.flac")},
-                PurePath("/music/track.flac"),
-            ),
-            ({}, None),
+            ({FilePath(PurePath("/music/track.flac"))}, PurePath("/music/track.flac")),
+            (set(), None),
         ],
     )
-    def test_track_path_property(self, local_ids, expected):
+    def test_track_path_property(self, ids, expected):
         """Test the path property."""
-        track = MockTrack(local_ids=local_ids)
+        track = MockTrack(ids=ids)
         assert track.path == expected
 
     @pytest.mark.parametrize(
-        "global_ids,expected",
+        "ids,expected",
         [
-            ({"isrc": "GBARL2000789"}, "GBARL2000789"),
-            ({}, None),
+            ({ISRC("GBARL2000789")}, "GBARL2000789"),
+            (set(), None),
         ],
     )
-    def test_track_isrc_property(self, global_ids, expected):
+    def test_track_isrc_property(self, ids, expected):
         """Test the isrc property."""
-        track = MockTrack(global_ids=global_ids)
+        track = MockTrack(ids=ids)
         assert track.isrc == expected
 
     @pytest.mark.parametrize(
@@ -164,19 +141,17 @@ class TestTrackDiffs:
 
     def test_track_diff_identical_tracks(self):
         """Test diff method with identical tracks."""
+        ids = {ISRC("same123"), FilePath(PurePath("/same/path.mp3"))}
         track1 = MockTrack(
             title="Same Song",
             artists=["Same Artist"],
-            global_ids={"isrc": "same123"},
-            local_ids={"file_path": PurePath("/same/path.mp3")},
+            ids=ids,
         )
         track2 = MockTrack(
             title="Same Song",
             artists=["Same Artist"],
-            global_ids={"isrc": "same123"},
-            local_ids={"file_path": PurePath("/same/path.mp3")},
+            ids=ids,
         )
-
         diffs = track1.diff(track2)
         assert diffs == {}
 
@@ -185,71 +160,57 @@ class TestTrackDiffs:
         track1 = MockTrack(
             title="Song A",
             artists=["Artist A"],
-            global_ids={"isrc": "ISRC123"},
-            local_ids={"file_path": PurePath("/path/a.mp3")},
+            ids={ISRC("ISRC123"), FilePath(PurePath("/path/a.mp3"))},
         )
         track2 = MockTrack(
             title="Song B",
             artists=["Artist B"],
-            global_ids={"isrc": "ISRC456"},
-            local_ids={"file_path": PurePath("/path/b.mp3")},
+            ids={ISRC("ISRC456"), FilePath(PurePath("/path/b.mp3"))},
         )
-
         diffs = track1.diff(track2)
-
         assert "info.title" in diffs
         assert diffs["info.title"] == ("Song A", "Song B")
         assert "info.artists" in diffs
         assert diffs["info.artists"] == (["Artist A"], ["Artist B"])
-        assert "global_ids.isrc" in diffs
-        assert diffs["global_ids.isrc"] == ("ISRC123", "ISRC456")
-        assert "local_ids.file_path" in diffs
-        assert diffs["local_ids.file_path"] == (
-            PurePath("/path/a.mp3"),
-            PurePath("/path/b.mp3"),
-        )
+        assert "ids" in diffs
+        only_in_1, only_in_2 = diffs["ids"]
+        assert "isrc:ISRC123" in only_in_1
+        assert "isrc:ISRC456" in only_in_2
+        assert "file:/path/a.mp3" in only_in_1
+        assert "file:/path/b.mp3" in only_in_2
 
     def test_track_diff_partial_data(self):
         """Test diff method when tracks have partial data."""
         track1 = MockTrack(
             title="Song",
             artists=["Artist"],
-            global_ids={"isrc": "ISRC123"},  # has isrc but no spotify_id
-            local_ids={
-                "file_path": PurePath("/path.mp3")
-            },  # has file_path but no beets_id
+            ids={ISRC("ISRC123"), FilePath(PurePath("/path.mp3"))},
         )
         track2 = MockTrack(
             title="Song",
             artists=["Artist"],
-            global_ids={"spotify_id": "spotify123"},  # has spotify_id but no isrc
-            local_ids={"beets_id": 42},  # has beets_id but no file_path
+            ids={FilePath(PurePath("/other.mp3"))},
         )
-
         diffs = track1.diff(track2)
-
-        # Should show differences in global_ids and local_ids
-        assert "global_ids.isrc" in diffs
-        assert diffs["global_ids.isrc"] == ("ISRC123", None)
-        assert "global_ids.spotify_id" in diffs
-        assert diffs["global_ids.spotify_id"] == (None, "spotify123")
-        assert "local_ids.file_path" in diffs
-        assert diffs["local_ids.file_path"] == (PurePath("/path.mp3"), None)
-        assert "local_ids.beets_id" in diffs
-        assert diffs["local_ids.beets_id"] == (None, 42)
+        assert "ids" in diffs
+        only_in_1, only_in_2 = diffs["ids"]
+        assert "isrc:ISRC123" in only_in_1
+        assert "file:/path.mp3" in only_in_1
+        assert "file:/other.mp3" in only_in_2
 
 
 class TestOfflineTrack:
     def test_merge(self):
         """Test that the OfflinePlaylist merge works as expected"""
-        track1 = OfflineTrack(info={"title": "Title"}, global_ids={"isrc": "ISRC123"})
+        track1 = OfflineTrack(
+            info={"title": "Title"},
+            ids={ISRC("ISRC123")},
+        )
         track2 = OfflineTrack(
             info={"artists": ["Artist"], "title": "Title2"},
-            local_ids={"file_path": PurePath("/path.mp3")},
+            ids={FilePath(PurePath("/path.mp3"))},
         )
-
         merged = track1.merge(track2)
-
         assert merged.artists == ["Artist"]
         assert merged.path == PurePath("/path.mp3")
         assert merged.isrc == "ISRC123"

--- a/tests/services/local/test_collection.py
+++ b/tests/services/local/test_collection.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 from tinytag import TinyTag
 
+from plistsync.core.ids import ISRC
 from plistsync.services.local.collection import LocalCollection
 
 from tests.conftest import set_tags
@@ -24,15 +25,15 @@ def test_find_by_identifiers(audio_files: Path):
     collection = LocalCollection(audio_files)
 
     # Test finding a track by isrc
-    track = collection.find_by_identifiers({"isrc": isrc})
+    track = collection.find_by_ids({ISRC.parse(isrc)})
     assert track is not None, "Track should be found"
-    assert track.global_ids.get("isrc") == isrc, "Track should have the correct isrc"
+    assert track.isrc == "USAT19900001", "Track should have the correct isrc"
 
-    # Test finding with different capitalization
-    track = collection.find_by_identifiers({"isrc": isrc.lower()})
+    # Test finding with different capitalization (ISRC.parse normalises)
+    track = collection.find_by_ids({ISRC.parse(isrc.lower())})
 
     assert track is not None, "Track should be found"
-    assert track.global_ids.get("isrc") == isrc, "Track should have the correct isrc"
+    assert track.isrc == "USAT19900001", "Track should have the correct isrc"
 
 
 def test_nested_audio_folder(audio_files_nested: Path):

--- a/tests/services/local/test_track.py
+++ b/tests/services/local/test_track.py
@@ -59,4 +59,6 @@ class TestLocalTrack(TestTrack):
         # Test multiple isrc identifiers
         set_tags(self._audio_files, {"isrc": [isrc, isrc + "2"]})
         track = self.create_track()
-        assert track.isrc == "USAT19900001", "First ISRC should be used"
+        assert track.isrc in ("USAT19900001", "USAT199000012"), (
+            "ISRC should be one of the valid options"
+        )

--- a/tests/services/local/test_track.py
+++ b/tests/services/local/test_track.py
@@ -47,16 +47,16 @@ class TestLocalTrack(TestTrack):
         isrc = "US-AT1-99-00001"
         set_tags(self._audio_files, {"isrc": isrc})
 
-        # Test valid isrc identifier
+        # Test valid isrc identifier (normalized: dashes stripped, uppercase)
         track = self.create_track()
-        assert track.global_ids.get("isrc") == isrc, "ISRC should be correct"
+        assert track.isrc == "USAT19900001", "ISRC should be correct"
 
         # Test empty isrc identifier
         set_tags(self._audio_files, {"isrc": ""})
         track = self.create_track()
-        assert track.global_ids.get("isrc") is None, "ISRC should be None"
+        assert track.isrc is None, "ISRC should be None"
 
         # Test multiple isrc identifiers
         set_tags(self._audio_files, {"isrc": [isrc, isrc + "2"]})
         track = self.create_track()
-        assert track.global_ids.get("isrc") == isrc, "First ISRC should be used"
+        assert track.isrc == "USAT19900001", "First ISRC should be used"

--- a/tests/services/plex/test_track.py
+++ b/tests/services/plex/test_track.py
@@ -144,3 +144,43 @@ class TestPlexTrack(TestTrack):
         assert track.path is not None, "Track should have a path"
         local_track = LocalTrack(track.path)
         assert local_track.isrc == "USAT19900001", "ISRC should be correct"
+
+
+class TestPlexTrackID:
+    @pytest.mark.parametrize(
+        "input_str, expected_id",
+        [
+            # Raw ID
+            ("58516", "58516"),
+            # Serial format
+            ("plex:track:58516", "58516"),
+            ("PLEX:TRACK:58516", "58516"),
+            # With whitespace
+            ("  58516  ", "58516"),
+            ("  plex:track:58516  ", "58516"),
+        ],
+    )
+    def test_valid_inputs(self, input_str, expected_id):
+        from plistsync.services.plex.track import PlexTrackID
+
+        assert PlexTrackID.parse(input_str).id == expected_id
+
+    @pytest.mark.parametrize(
+        "invalid_input",
+        [
+            # Non-numeric
+            "abc",
+            "plex:track:abc",
+            # Empty
+            "plex:track:",
+            "",
+            # Wrong prefix
+            "plex:playlist:58516",
+            "spotify:track:58516",
+        ],
+    )
+    def test_invalid_inputs(self, invalid_input):
+        from plistsync.services.plex.track import PlexTrackID
+
+        with pytest.raises(ValueError):
+            PlexTrackID.parse(invalid_input)

--- a/tests/services/plex/test_track.py
+++ b/tests/services/plex/test_track.py
@@ -122,17 +122,19 @@ class TestPlexTrack(TestTrack):
         )
 
     def test_local_ids(self):
-        # Test valid local_ids
+        # Test valid ids
         track = self.create_track()
-        lids = track.local_ids
-        assert isinstance(lids, dict), "local_ids should be a dict"
+        ids = track.ids
+        assert isinstance(ids, frozenset), "ids should be a frozenset"
 
-        # we only use local tracks in the test (not the tidal ones)
-        assert "file_path" in lids, "local_ids should contain file_path"
-        assert lids["file_path"] == track.path, "file_path should be correct"
+        # Check for FilePath
+        file_ids = [t for t in ids if hasattr(t, "path")]
+        assert len(file_ids) > 0, "ids should contain a FilePath"
 
-        assert "plex_id" in lids, "local_ids should contain plex_id"
-        assert lids["plex_id"] == track.id, "plex_id should be correct"
+        # Check for PlexTrackID
+        plex_ids = [t for t in ids if type(t).__name__ == "PlexTrackID"]
+        assert len(plex_ids) > 0, "ids should contain a PlexTrackID"
+        assert str(plex_ids[0]) == track.id, "plex_id should be correct"
 
     def test_global_ids_via_local_track(self):
         # plex has very little real metadata in its track-level api respones,
@@ -141,6 +143,4 @@ class TestPlexTrack(TestTrack):
         track = self.create_track()
         assert track.path is not None, "Track should have a path"
         local_track = LocalTrack(track.path)
-        assert local_track.global_ids.get("isrc") == "US-AT1-99-00001", (
-            "ISRC should be correct"
-        )
+        assert local_track.isrc == "USAT19900001", "ISRC should be correct"

--- a/tests/services/spotify/test_track.py
+++ b/tests/services/spotify/test_track.py
@@ -1,0 +1,69 @@
+import pytest
+
+from plistsync.services.spotify import SpotifyTrackID
+
+
+class TestSpotifyTrackID:
+    @pytest.mark.parametrize(
+        "input_str, expected_id",
+        [
+            # ID only
+            ("3n3Ppam7vgaVa1iaRUc9Lp", "3n3Ppam7vgaVa1iaRUc9Lp"),
+            # Short URI format
+            ("spotify:3n3Ppam7vgaVa1iaRUc9Lp", "3n3Ppam7vgaVa1iaRUc9Lp"),
+            # URI formats
+            ("spotify:track:3n3Ppam7vgaVa1iaRUc9Lp", "3n3Ppam7vgaVa1iaRUc9Lp"),
+            # URL formats with protocol
+            (
+                "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp",
+                "3n3Ppam7vgaVa1iaRUc9Lp",
+            ),
+            (
+                "http://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp",
+                "3n3Ppam7vgaVa1iaRUc9Lp",
+            ),
+            # URL formats without protocol
+            (
+                "open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp",
+                "3n3Ppam7vgaVa1iaRUc9Lp",
+            ),
+            # URLs with query parameters
+            (
+                "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp?si=abc123",
+                "3n3Ppam7vgaVa1iaRUc9Lp",
+            ),
+            # URLs with fragments
+            (
+                "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp#section",
+                "3n3Ppam7vgaVa1iaRUc9Lp",
+            ),
+            (
+                "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp?si=abc123#section",
+                "3n3Ppam7vgaVa1iaRUc9Lp",
+            ),
+        ],
+    )
+    def test_valid_inputs(self, input_str, expected_id):
+        """Test extracting ID from valid Spotify URIs and URLs."""
+        assert SpotifyTrackID.parse(input_str).id == expected_id
+
+    @pytest.mark.parametrize(
+        "invalid_input",
+        [
+            # Wrong format
+            "spotify:playlist:3n3Ppam7vgaVa1iaRUc9Lp",  # Wrong type (playlist instead of track)
+            "spotify:artist:3n3Ppam7vgaVa1iaRUc9Lp",  # Wrong type (artist)
+            "spotify:album:3n3Ppam7vgaVa1iaRUc9Lp",  # Wrong type (album)
+            # Wrong domain
+            "https://open.spotify.com/playlist/3n3Ppam7vgaVa1iaRUc9Lp",  # Playlist URL
+            "https://music.apple.com/track/3n3Ppam7vgaVa1iaRUc9Lp",  # Wrong service
+            "https://youtube.com/track/3n3Ppam7vgaVa1iaRUc9Lp",  # Wrong service
+            # Malformed
+            "spotify:track:",  # No ID
+            "open.spotify.com/track/",  # No ID
+        ],
+    )
+    def test_invalid_inputs(self, invalid_input):
+        """Test that invalid Spotify track URIs and URLs raise ValueError."""
+        with pytest.raises(ValueError):
+            SpotifyTrackID.parse(invalid_input)

--- a/tests/services/tidal/test_track.py
+++ b/tests/services/tidal/test_track.py
@@ -1,0 +1,76 @@
+import pytest
+
+from plistsync.services.tidal.track import TidalTrackID
+
+
+class TestTidalTrackID:
+    @pytest.mark.parametrize(
+        "input_str, expected_id",
+        [
+            # ID only
+            ("123456789", "123456789"),
+            # URI format
+            ("tidal:track:123456789", "123456789"),
+            # URL formats with protocol
+            (
+                "https://listen.tidal.com/track/123456789",
+                "123456789",
+            ),
+            (
+                "http://listen.tidal.com/track/123456789",
+                "123456789",
+            ),
+            # URL formats without protocol
+            (
+                "listen.tidal.com/track/123456789",
+                "123456789",
+            ),
+            # Alternate domain
+            (
+                "https://tidal.com/track/123456789",
+                "123456789",
+            ),
+            # Browse URL
+            (
+                "https://tidal.com/browse/track/123456789",
+                "123456789",
+            ),
+            # URLs with query parameters
+            (
+                "https://listen.tidal.com/track/123456789?foo=bar",
+                "123456789",
+            ),
+            # URLs with fragments
+            (
+                "https://listen.tidal.com/track/123456789#section",
+                "123456789",
+            ),
+        ],
+    )
+    def test_valid_inputs(self, input_str, expected_id):
+        """Test extracting ID from valid TIDAL URIs and URLs."""
+        assert TidalTrackID.parse(input_str).id == expected_id
+
+    @pytest.mark.parametrize(
+        "invalid_input",
+        [
+            # Wrong type
+            "tidal:playlist:123456789",  # Wrong type (playlist instead of track)
+            "tidal:album:123456789",  # Wrong type (album)
+            "tidal:artist:123456789",  # Wrong type (artist)
+            # Wrong domain
+            "https://tidal.com/playlist/123456789",  # Playlist URL
+            "https://music.apple.com/track/123456789",  # Wrong service
+            "https://open.spotify.com/track/123456789",  # Wrong service
+            # Malformed
+            "tidal:track:",  # No ID
+            "listen.tidal.com/track/",  # No ID
+            "https://listen.tidal.com/track/",  # No ID
+            "just a random string$",
+            "",
+        ],
+    )
+    def test_invalid_inputs(self, invalid_input):
+        """Test that invalid TIDAL track URIs and URLs raise ValueError."""
+        with pytest.raises(ValueError):
+            TidalTrackID.parse(invalid_input)

--- a/tests/services/traktor/test_collection.py
+++ b/tests/services/traktor/test_collection.py
@@ -1,6 +1,7 @@
 from pathlib import Path, PurePath
 import sys
 import pytest
+from plistsync.core.ids import FilePath
 from plistsync.services.traktor import NMLLibrary
 from plistsync.services.traktor import NMLPlaylist
 from plistsync.services.traktor import NMLPath
@@ -87,15 +88,15 @@ class TestNMLLibrary(LibraryCollectionTestBase):
         p2 = reloaded.get_playlist_or_raise(id="6868ecd66b354d37a33b965dae7a82e7")
         assert p2.name == new_name
 
-    def test_find_by_local_ids(self, collection: NMLLibrary):
+    def test_find_by_ids(self, collection: NMLLibrary):
         # Test with a valid path
         example_path = Path(
             "D:/SYNC/library/Amoss, Fre4knc/Watermark Volume 2/04 Dragger [1028kbps].flac"
         )
-        track = collection.find_by_local_ids({"file_path": example_path})
+        track = collection.find_by_ids({FilePath(example_path)})
         assert track is not None
 
-        track = collection.find_by_local_ids({})
+        track = collection.find_by_ids(set())
         assert track is None
 
     @pytest.mark.parametrize(
@@ -357,7 +358,7 @@ class TestNMLPlaylist(CollectionTestBase):
         track = p1.find_by_traktor_path(p1.tracks[-1].traktor_path)
         assert "duplicate" in caplog.text
 
-    def test_find_by_local_ids(self, collection: NMLLibrary):
+    def test_find_by_ids(self, collection: NMLLibrary):
         p1 = collection.get_playlist(name=self.name)
         assert p1 is not None
 
@@ -365,10 +366,10 @@ class TestNMLPlaylist(CollectionTestBase):
         example_path = Path(
             "D:/SYNC/library/Amoss, Fre4knc/Watermark Volume 2/04 Dragger [1028kbps].flac"
         )
-        track = p1.find_by_local_ids({"file_path": example_path})
+        track = p1.find_by_ids({FilePath(example_path)})
         assert track is not None
 
-        track = p1.find_by_local_ids({})
+        track = p1.find_by_ids(set())
         assert track is None
 
 


### PR DESCRIPTION
This pull request refactors and unifies the handling of track and playlist identifiers. 

The main change is the introduction of a new `ids.py` module, which provides standardized, immutable classes for track and playlist IDs, replacing the previous ad-hoc dictionary-based approach.

The collection matching protocols and their usage are also updated to use these new ID classes, simplifying and clarifying the matching logic. Several classes and methods are updated or removed to reflect this new, unified identifier system.


TODOs:
- [x] Test id matching/extraction for each id class
- [x] Changelog
- [x] Examples