### PR TITLE
SyncedPlaylist - bidirectional playlist synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This improves type safety, clarity, and extensibility for playlist identificatio
 
 - Added typed `Service` marker class with a module-inferred `name` property and registry-backed accessors (`library()`, `tracks()`, `track_ids()`, `playlist_ids()`), enabling single-handle access to all a service's core types. (#95)
 - Added generic `Registry` base class that auto-registers concrete implementations by service name at class-definition time. `Track`, `Library`, `TrackID`, and `PlaylistID` are now registry roots, making service classes discoverable simply by importing their module.
+- Added `SerialID` base class unifying the identifier contract (`parse`/`serial`) with a service-derived namespace `prefix()` that is enforced on construction. `TrackID.from_serial()` and `PlaylistID.from_serial()` resolve a serial string to the correct service's identifier class via `ServiceLoader`.
 - Added a migration example to fully copy a playlist from an arbitrary service to another. (#60)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - Refactored track identifier handling across the codebase by replacing service-specific `TrackIds` dictionaries with strongly typed, immutable `TrackID` dataclasses for each service (e.g. Spotify, Plex).
-- Refactored playlist identifier handling across the codebase by replacing service-specific `PlaylistIds` dictionaries with strongly typed, immutable `PlaylistID` dataclasses for each service (e.g. Spotify, Plex). 
+- Refactored playlist identifier handling across the codebase by replacing service-specific `PlaylistIds` dictionaries with strongly typed, immutable `PlaylistID` dataclasses for each service (e.g. Spotify, Plex).
   - Removed obsolete playlist ID extraction utilities that are no longer required under the new identifier system.
   - Updated all playlist operations and internal synchronization flows to use the new typed identifier model consistently.
 
 This improves type safety, clarity, and extensibility for playlist identification and lookup operations. All playlist-related APIs and synchronization logic now operate on explicit identifier types instead of loosely structured dictionaries.
 
+- Replaced the import-based `ServiceRegistry` with entry-point based service discovery via `ServiceLoader` (`ServiceLoader.get(name)` / `ServiceLoader.all()`). Services are now discovered through the `plistsync.services` entry-point group without importing all service modules, and services with missing optional dependencies are skipped gracefully.
+- Removed the `track_cls`, `library_cls`, `playlist_cls` and `playlist_id_cls` attributes from `Service` implementations; registered classes are resolved through the `Registry` instead.
+- `OfflinePlaylist` now takes a typed `PlaylistID` (`id=...`) instead of an `id_serial` string.
+
 ### Added
 
-- Added typed `Service` marker class with `track_cls`, `library_cls`, `playlist_cls` attributes and module-inferred `name` property, enabling single-handle access to all a service's core types. (#95)
+- Added typed `Service` marker class with a module-inferred `name` property and registry-backed accessors (`library()`, `tracks()`, `track_ids()`, `playlist_ids()`), enabling single-handle access to all a service's core types. (#95)
+- Added generic `Registry` base class that auto-registers concrete implementations by service name at class-definition time. `Track`, `Library`, `TrackID`, and `PlaylistID` are now registry roots, making service classes discoverable simply by importing their module.
 - Added a migration example to fully copy a playlist from an arbitrary service to another. (#60)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ This improves type safety, clarity, and extensibility for playlist identificatio
 - Added generic `Registry` base class that auto-registers concrete implementations by service name at class-definition time. `Track`, `Library`, `TrackID`, and `PlaylistID` are now registry roots, making service classes discoverable simply by importing their module.
 - Added `SerialID` base class unifying the identifier contract (`parse`/`serial`) with a service-derived namespace `prefix()` that is enforced on construction. `TrackID.from_serial()` and `PlaylistID.from_serial()` resolve a serial string to the correct service's identifier class via `ServiceLoader`.
 - Added a migration example to fully copy a playlist from an arbitrary service to another. (#60)
+- Added `SyncedPlaylist` class for bidirectional playlist synchronization across an arbitrary number of services. This class encapsulates the logic for detecting differences, applying updates, and maintaining a consistent state across all linked services. (#100)
+  - Conflict-free state replication via a CRDT (Fugue): each linked playlist acts as a replica, so changes made directly on a service (outside plistsync) merge cleanly without conflicts.
+  - Phased `sync()` pipeline: `refresh()` pulls the current state from each service, `merge()` reconciles external additions/removals/reorders into the internal collection, `enrich()` cross-links tracks between services and backfills missing identifiers (e.g. ISRCs), and `push()` writes the resolved state back to every linked playlist.
+  - Track association is availability-aware: tracks that cannot be resolved on a given service are skipped for that service instead of being dropped from the internal collection.
+  - Added `SyncedPlaylistID`, a UUID-based playlist identifier for synced playlists.
 
 ### Fixed
 

--- a/docs/services/plex/collections.ipynb
+++ b/docs/services/plex/collections.ipynb
@@ -21,6 +21,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from __future__ import annotations\n",
+    "\n",
     "from plistsync.services.plex import PlexLibrary\n",
     "\n",
     "library = PlexLibrary(section_name_or_id=\"Music\")"
@@ -281,7 +283,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plistsync.services.plex import PlexTrack\n",
+    "from typing import TYPE_CHECKING\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from plistsync.services.plex import PlexTrack\n",
     "\n",
     "# find some tracks to play around with\n",
     "new_tracks: list[PlexTrack] = list(\n",

--- a/docs/services/traktor/collections.ipynb
+++ b/docs/services/traktor/collections.ipynb
@@ -47,6 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from __future__ import annotations\n",
+    "\n",
     "from plistsync.services.traktor import NMLLibrary\n",
     "\n",
     "library = NMLLibrary(path=\"/Users/paul/Music/Traktor/collection.nml\")"
@@ -81,9 +83,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import PurePath, PurePosixPath, PureWindowsPath\n",
+    "from pathlib import PurePosixPath, PureWindowsPath\n",
+    "from typing import TYPE_CHECKING\n",
     "\n",
     "from plistsync.core.ids import FilePath\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from pathlib import PurePath\n",
     "\n",
     "path: PurePath = PureWindowsPath(\n",
     "    r\"D:\\SYNC\\library\\Amoss, Fre4knc\\Watermark Volume 2\\04 Dragger [1028kbps].flac\"\n",

--- a/examples/community/migrate.py
+++ b/examples/community/migrate.py
@@ -12,7 +12,7 @@ import typer
 
 from plistsync.core import Library, Matches, ServicePlaylist, Track
 from plistsync.logger import log
-from plistsync.services import ServiceRegistry
+from plistsync.services import ServiceLoader
 
 
 class MigrationContext(NamedTuple):
@@ -138,28 +138,28 @@ def main(
         ),
     ] = True,
 ):
-    if not (_from_service := ServiceRegistry.get(from_service.lower())):
+    if not (_from_service := ServiceLoader.get(from_service.lower())):
         log.error(
             f"Invalid from_service {from_service!r}.\n"
-            f"Pick one of {list(ServiceRegistry.dict().keys())}"
+            f"Pick one of {list(ServiceLoader.all().keys())}"
         )
         sys.exit(1)
 
-    if _from_service.library_cls is None:
+    if (from_library_cls := _from_service.library()) is None:
         log.error(
             f"Invalid from_service {_from_service}.\n"
             "Does not support library based operations."
         )
         sys.exit(1)
 
-    if not (_to_service := ServiceRegistry.get(to_service.lower())):
+    if not (_to_service := ServiceLoader.get(to_service.lower())):
         log.error(
             f"Invalid to_service {to_service!r}.\n"
-            f"Pick one of {list(ServiceRegistry.dict().keys())}."
+            f"Pick one of {list(ServiceLoader.all().keys())}."
         )
         sys.exit(1)
 
-    if _to_service.library_cls is None:
+    if (to_library_cls := _to_service.library()) is None:
         log.error(
             f"Invalid to_service {_to_service}.\n"
             "Does not support library based operations."
@@ -171,8 +171,8 @@ def main(
         sys.exit(1)
 
     migrate_library(
-        _from_service.library_cls(),
-        _to_service.library_cls(),
+        from_library_cls(),
+        to_library_cls(),
         MigrationContext(overwrite=overwrite, skip_empty=skip_empty),
     )
 

--- a/examples/sync_spotify_tidal.ipynb
+++ b/examples/sync_spotify_tidal.ipynb
@@ -39,6 +39,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from __future__ import annotations\n",
+    "\n",
     "name = \"Fresh Songs\"\n",
     "description = \"New songs from the last 2 weeks.\""
    ]
@@ -136,8 +138,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from typing import TYPE_CHECKING\n",
+    "\n",
     "from plistsync.core.diff import list_diff\n",
-    "from plistsync.core.track import Track\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from plistsync.core.track import Track\n",
     "\n",
     "\n",
     "def hash_func(x: Track):\n",
@@ -184,8 +190,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from typing import TYPE_CHECKING\n",
+    "\n",
     "from plistsync.core.diff import DeleteOp, InsertOp, MoveOp\n",
-    "from plistsync.services.tidal.track import TidalPlaylistTrack, TidalTrack\n",
+    "from plistsync.services.tidal.track import TidalPlaylistTrack\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from plistsync.services.tidal.track import TidalTrack\n",
     "\n",
     "# After closing the `edit` context manager\n",
     "# the changes are minified, batched and applied\n",

--- a/examples/sync_spotify_tidal.ipynb
+++ b/examples/sync_spotify_tidal.ipynb
@@ -146,7 +146,7 @@
     "    from plistsync.core.track import Track\n",
     "\n",
     "\n",
-    "def hash_func(x: Track):\n",
+    "def key_func(x: Track):\n",
     "    \"\"\"Return a stable identity key for diffing tracks across services.\n",
     "\n",
     "    `list_diff` groups and compares items using this key. If two tracks produce\n",
@@ -163,7 +163,7 @@
     "ops = list_diff(\n",
     "    old=tidal_playlist.tracks,  # current state (to be updated)\n",
     "    new=spotify_playlist.tracks,  # desired state (source of truth)\n",
-    "    hash_func=hash_func,\n",
+    "    key_func=key_func,\n",
     ")"
    ]
   },

--- a/examples/transcode_playlist.ipynb
+++ b/examples/transcode_playlist.ipynb
@@ -11,6 +11,8 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import annotations\n",
+    "\n",
     "import shutil\n",
     "\n",
     "if shutil.which(\"ffmpeg\") is None:\n",
@@ -182,8 +184,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from typing import TYPE_CHECKING\n",
+    "\n",
     "from plistsync.services.local import LocalTrack\n",
-    "from plistsync.services.traktor import NMLPlaylistTrack, NMLTrack\n",
+    "\n",
+    "if TYPE_CHECKING:\n",
+    "    from plistsync.services.traktor import NMLPlaylistTrack, NMLTrack\n",
     "\n",
     "\n",
     "def to_local_track(track: NMLPlaylistTrack | NMLTrack) -> LocalTrack:\n",

--- a/plistsync/__main__.py
+++ b/plistsync/__main__.py
@@ -7,7 +7,7 @@ import typer
 from eyconf.cli import create_config_cli
 from rich.logging import RichHandler
 
-from plistsync.services import ServiceRegistry
+from plistsync.services import ServiceLoader
 
 from .config import Config
 from .errors import DependencyError
@@ -110,7 +110,7 @@ def version_callback(value: bool) -> None:
     from importlib.metadata import version
 
     ver = version("plistsync")
-    services = [service for service in ServiceRegistry.dict().keys()]
+    services = [service for service in ServiceLoader.all().keys()]
 
     svc_str = ", ".join(services) if services else "none"
     typer.echo(f"plistsync: {ver}  ({svc_str})")

--- a/plistsync/core/__init__.py
+++ b/plistsync/core/__init__.py
@@ -16,12 +16,12 @@ from .track import Track, TrackInfo
 __all__ = [
     "Collection",
     "Library",
+    "Matches",
     "PathRewrite",
-    "Track",
-    "TrackInfo",
     "Playlist",
     "PlaylistID",
-    "TrackID",
     "ServicePlaylist",
-    "Matches",
+    "Track",
+    "TrackID",
+    "TrackInfo",
 ]

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -56,6 +56,8 @@ from typing import (
 
 from typing_extensions import TypeVar
 
+from plistsync.services.registry import Registry
+
 from .ids import Scope, TrackID
 from .matching import Matches, Similarity, fuzzy_match
 from .track import Track, TrackInfo
@@ -363,7 +365,7 @@ class Collection(ABC, Generic[T]):
         )
 
 
-class Library(Generic[T, Plist], Collection[T]):
+class Library(Generic[T, Plist], Collection[T], ABC, Registry):
     """Represents a collection of tracks in a library with playlist management.
 
     This class serves as a base for library collections across diverse services.

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 
 import itertools
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import (
     TYPE_CHECKING,
@@ -58,17 +57,21 @@ from typing_extensions import TypeVar
 
 from plistsync.services.registry import Registry
 
-from .ids import Scope, TrackID
-from .matching import Matches, Similarity, fuzzy_match
-from .track import Track, TrackInfo
+from .ids import Scope
+from .matching import Matches, fuzzy_match
+from .track import Track
 
 R = TypeVar("R")
 P = ParamSpec("P")
 T = TypeVar("T", bound=Track, covariant=True)
 
 if TYPE_CHECKING:
-    from .ids import PlaylistID
+    from collections.abc import Callable, Iterable, Sequence
+
+    from .ids import PlaylistID, TrackID
+    from .matching import Similarity
     from .playlist import Playlist
+    from .track import TrackInfo
 
 
 Plist = TypeVar("Plist", bound="Playlist", default="Playlist", covariant=True)

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -70,11 +70,13 @@ if TYPE_CHECKING:
 
     from .ids import PlaylistID, TrackID
     from .matching import Similarity
-    from .playlist import Playlist
+    from .playlist import ServicePlaylist
     from .track import TrackInfo
 
 
-Plist = TypeVar("Plist", bound="Playlist", default="Playlist", covariant=True)
+Plist = TypeVar(
+    "Plist", bound="ServicePlaylist", default="ServicePlaylist", covariant=True
+)
 
 
 @runtime_checkable

--- a/plistsync/core/crdt/__init__.py
+++ b/plistsync/core/crdt/__init__.py
@@ -1,10 +1,14 @@
 """Minimal Conflict Free Replicatable Data Types implementations."""
 
 from .fugue import DeleteOp, Fugue, InsertOp, InsertPos
+from .lww import LWWRegister, RegisterOp
 
 __all__ = [
     "DeleteOp",
     "Fugue",
+    "Fugue",
     "InsertOp",
     "InsertPos",
+    "LWWRegister",
+    "RegisterOp",
 ]

--- a/plistsync/core/crdt/__init__.py
+++ b/plistsync/core/crdt/__init__.py
@@ -4,7 +4,7 @@ from .fugue import DeleteOp, Fugue, InsertOp, InsertPos
 
 __all__ = [
     "DeleteOp",
+    "Fugue",
     "InsertOp",
     "InsertPos",
-    "Fugue",
 ]

--- a/plistsync/core/crdt/fugue.py
+++ b/plistsync/core/crdt/fugue.py
@@ -5,12 +5,14 @@ Inspired by *The Art of the Fugue* by Weidner & Kleppmann.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from .graph import Graph, Node, NodeID, Side
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 T = TypeVar("T")
 

--- a/plistsync/core/crdt/lww.py
+++ b/plistsync/core/crdt/lww.py
@@ -1,0 +1,176 @@
+"""Op-based Last-Writer-Wins Register CRDT.
+
+Same design as the Fugue: an append-only log of operations whose
+current value is *derived* by folding the log.
+
+Used to synchronise playlist metadata (name, description) with the
+same replica-versioned clock as the Fugue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
+
+from .graph import NodeID
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+T = TypeVar("T")
+
+
+def _lww_key(version: NodeID) -> tuple[int, int]:
+    """Lamport ordering key: logical counter first, replica id as tie-breaker.
+
+    ``NodeID`` orders by ``(replica_id, counter)`` (replica id first), which
+    is what the Fugue wants for sibling placement but is *not* Lamport order.
+    Comparing by this key keeps last-writer-wins semantics independent of the
+    Fugue's structural ordering.
+    """
+    return (version.counter, version.replica_id)
+
+
+@dataclass(frozen=True)
+class RegisterOp(Generic[T]):
+    """A single assignment to one field of the register."""
+
+    key: str
+    value: T
+    version: NodeID
+
+
+class LWWRegister(Mapping[str, Any]):
+    """Op-based last-writer-wins register for named fields.
+
+    Each field stores the value associated with the operation having the
+    highest NodeID version. Versions are ordered by Lamport timestamp
+    semantics (counter first, replica id as a tie-breaker), ensuring that
+    concurrent updates converge to the same winner across replicas.
+
+    The register keeps the full operation history so replicas can merge by
+    replaying operations they have not seen yet.
+
+    Fields are heterogeneous, so the register is accessed like a mapping::
+
+        reg = LWWRegister(replica_id=0)
+        reg["name"] = "Mix"  # creates an op for field "name"
+        reg.assign("description", "Desc")
+        dict(reg)  # current field values
+    """
+
+    def __init__(self, replica_id: int = 0) -> None:
+        # Replica identity is used to create globally unique operation versions.
+        self.replica_id: int = replica_id
+
+        # Scalar Lamport clock. Advanced in exactly one place (apply) to one
+        # past the highest counter observed, so versions stay unique and
+        # causally ordered. ``assign`` timestamps from the current value.
+        self._counter: int = 0
+
+        # Keep operation history so replicas can merge by replaying operations.
+        self._ops: list[RegisterOp[Any]] = []
+
+        # Current winning version and value for each field.
+        self._winners: dict[str, NodeID] = {}
+        self._values: dict[str, Any] = {}
+
+        # Prevent applying the same operation more than once.
+        self._seen_versions: set[NodeID] = set()
+
+    def apply(self, op: RegisterOp[Any]) -> bool:
+        """Apply local or remote op; return True if it wins."""
+        if op.version in self._seen_versions:
+            return False
+
+        self._seen_versions.add(op.version)
+        self._ops.append(op)
+
+        # Lamport receive rule: advance past the highest counter observed,
+        # regardless of which replica the op came from.
+        self._counter = max(self._counter, op.version.counter + 1)
+
+        cur = self._winners.get(op.key)
+        if cur is None or _lww_key(op.version) > _lww_key(cur):
+            self._winners[op.key] = op.version
+            self._values[op.key] = op.value
+            return True
+        return False
+
+    def assign(self, field_name: str, value: Any) -> RegisterOp[Any]:
+        """Create and apply a local op.
+
+        The op is timestamped with the current Lamport clock; ``apply`` then
+        advances the clock, so the first local op gets counter 0 and each
+        subsequent op a strictly higher counter.
+        """
+        version = NodeID(self.replica_id, self._counter)
+        op = RegisterOp(key=field_name, value=value, version=version)
+        self.apply(op)
+        return op
+
+    def history(self, field_name: str) -> list[RegisterOp[Any]]:
+        return [op for op in self._ops if op.key == field_name]
+
+    def last_op_by(self, field_name: str, replica_id: int) -> RegisterOp[Any] | None:
+        """Return the most recent op written to *field_name* by *replica_id*.
+
+        Returns None if that replica has never written to the field. Used as
+        the per-replica baseline when diffing snapshot-based replicas: only
+        their own last write is meaningful (the current winner may come from
+        another replica).
+        """
+        for op in reversed(self._ops):
+            if op.key == field_name and op.version.replica_id == replica_id:
+                return op
+        return None
+
+    def __getitem__(self, field_name: str) -> Any:
+        """Return the current value for *field_name*.
+
+        Raise KeyError if it has never been assigned.
+        """
+        try:
+            return self._values[field_name]
+        except KeyError:
+            raise KeyError(f"no value for field {field_name!r}") from None
+
+    def __setitem__(self, field_name: str, value: Any) -> None:
+        """Assign *value* to *field_name*; shorthand for :meth:`assign`."""
+        self.assign(field_name, value)
+
+    def __delitem__(self, field_name: str) -> None:
+        # Fields cannot be deleted: the op log is append-only, so removal
+        # has no CRDT semantics (it would require tombstones).
+        raise TypeError(f"{type(self).__name__} does not support field deletion")
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def fork(self, replica_id: int) -> Self:
+        """Return an independent copy with a new *replica_id*."""
+        new = deepcopy(self)
+        new.replica_id = replica_id
+        return new
+
+    def merge(self, other: LWWRegister) -> None:
+        """Merge operations from another register into this one."""
+        for op in other._ops:
+            self.apply(op)
+
+    def version(self) -> NodeID:
+        """Return the current Lamport clock as a NodeID."""
+        return NodeID(self.replica_id, self._counter)
+
+    def time_travel(self, version: NodeID) -> Self:
+        """Return a new register containing only ops causally before *version*."""
+        new = type(self)(replica_id=self.replica_id)
+        for op in self._ops:
+            if _lww_key(op.version) < _lww_key(version):
+                new.apply(op)
+        return new

--- a/plistsync/core/crdt/serialize.py
+++ b/plistsync/core/crdt/serialize.py
@@ -134,7 +134,7 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
         values = data["values"]
         for op in data["ops"]:
             if "value_ref" in op:  # insert
-                ins = cast(OpStateInsert, op)
+                ins = cast("OpStateInsert", op)
                 value = self.serializer.load(values[ins["value_ref"]])
                 fugue.apply(
                     InsertOp(

--- a/plistsync/core/diff.py
+++ b/plistsync/core/diff.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import bisect
 from abc import ABC
 from collections import Counter, defaultdict
-from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeAlias, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence
 
 T = TypeVar("T")
 

--- a/plistsync/core/diff.py
+++ b/plistsync/core/diff.py
@@ -167,10 +167,14 @@ def batch_consecutive(
         yield batch
 
 
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+
 def list_diff(
     old: Sequence[T],
     new: Sequence[T],
-    hash_func: Callable[[T], Hashable],
+    key_func: Callable[[T], Hashable],
 ) -> Operations[T]:
     """Compute minimal insert/delete/move operations between lists.
 
@@ -180,7 +184,7 @@ def list_diff(
         Original track list.
     new : list[T]
         Target track list.
-    hash_func : Callable[[T], Hashable]
+    key_func : Callable[[T], Hashable]
         Function that returns a hashable key for logical equality.
 
     Returns
@@ -195,8 +199,8 @@ def list_diff(
     """
     live_list: list[T] = []  # Keep track of the current operations
 
-    old_keys = [hash_func(t) for t in old]
-    new_keys = [hash_func(t) for t in new]
+    old_keys = [key_func(t) for t in old]
+    new_keys = [key_func(t) for t in new]
     new_counts = Counter(new_keys)
 
     # 1. Delete excess duplicates (keep first N occurrences of each key)
@@ -226,7 +230,7 @@ def list_diff(
     hash_to_indices: dict[Hashable, list[int]] = defaultdict(list)
     unmatched_old_indices = list(range(len(live_list)))
     for idx, item in enumerate(live_list):
-        hash_to_indices[hash_func(item)].append(idx)
+        hash_to_indices[key_func(item)].append(idx)
 
     def shift_indices(indices: list[int], threshold: int, delta: int) -> None:
         pos = bisect.bisect_left(indices, threshold)
@@ -234,7 +238,7 @@ def list_diff(
             indices[i] += delta
 
     for target_idx, target_item in enumerate(new):
-        hash = hash_func(target_item)
+        hash = key_func(target_item)
         matched_old_idx = None
         # Get first unmatched old item with matching key
         if hash_to_indices[hash]:
@@ -276,4 +280,99 @@ def list_diff(
             shift_indices(unmatched_old_indices, target_idx, +1)
             for lst in hash_to_indices.values():
                 shift_indices(lst, target_idx, +1)
+    return Operations(ops, list(old))
+
+
+def list_diff_eq(
+    old: Sequence[T],
+    new: Sequence[T],
+    eq_func: Callable[[T, T], bool],
+) -> Operations[T]:
+    """Compute minimal insert/delete/move operations between lists using equality.
+
+    Unlike `list_diff`, this uses a binary equality function instead of a hash
+    function, enabling partial matching (e.g., matching by track ID while
+    ignoring other metadata fields that may differ between services).
+
+    Parameters
+    ----------
+    old : Sequence[T]
+        Original list.
+    new : Sequence[T]
+        Target list.
+    eq_func : Callable[[T, T], bool]
+        Function that returns True if two items are considered equal.
+
+    Returns
+    -------
+    Operations[T]
+        Minimal operations to transform old into new.
+
+    Qwirks
+    ------
+    Delete operations are always done first.
+
+    Complexity is O(n*m) due to linear scans (no hashing).
+
+    """
+    # Phase 1: Greedily match old items to new items (first-come-first-served).
+    # This single matching pass determines both which old items survive
+    # and where they should end up, avoiding inconsistency between phases.
+    old_to_new: dict[int, int] = {}  # old_idx -> new_idx
+    new_to_old: dict[int, int] = {}  # new_idx -> old_idx
+    new_matched: set[int] = set()
+
+    for old_idx, old_item in enumerate(old):
+        for new_idx, new_item in enumerate(new):
+            if new_idx not in new_matched and eq_func(old_item, new_item):
+                old_to_new[old_idx] = new_idx
+                new_to_old[new_idx] = old_idx
+                new_matched.add(new_idx)
+                break
+
+    # Phase 2: Delete unmatched old items.
+    indices_to_delete = sorted(i for i in range(len(old)) if i not in old_to_new)
+    del_set = set(indices_to_delete)
+
+    live_list: list[T] = []
+    for idx, item in enumerate(old):
+        if idx not in del_set:
+            live_list.append(item)
+
+    ops: list[InsertOp[T] | DeleteOp[T] | MoveOp[T]] = []
+    for idx in reversed(indices_to_delete):
+        ops.append(DeleteOp(item=old[idx], idx=idx))
+
+    # Phase 3: Apply moves and inserts using the pre-computed matching.
+    # live_to_old tracks which original old_idx is at each live position;
+    # -1 marks positions occupied by newly inserted items.
+    live_to_old: list[int] = [idx for idx in range(len(old)) if idx not in del_set]
+
+    for target_idx, target_item in enumerate(new):
+        if target_idx in new_to_old:
+            # This new slot was matched to a surviving old item — move it.
+            matched_old_idx = new_to_old[target_idx]
+            try:
+                matched_live_idx = live_to_old.index(matched_old_idx)
+            except ValueError:
+                continue  # Should not happen with consistent matching.
+
+            if matched_live_idx != target_idx:
+                ops.append(
+                    MoveOp(
+                        old_idx=matched_live_idx,
+                        new_idx=target_idx,
+                        item=live_list[matched_live_idx],
+                    )
+                )
+                val = live_list.pop(matched_live_idx)
+                live_list.insert(target_idx, val)
+                old_idx_val = live_to_old.pop(matched_live_idx)
+                live_to_old.insert(target_idx, old_idx_val)
+        else:
+            # No old item matches this new slot — insert.
+            ops.append(InsertOp(idx=target_idx, item=target_item))
+            live_list.insert(target_idx, target_item)
+            live_to_old.insert(target_idx, -1)
+
     return Operations(ops, list(old))

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -13,7 +13,7 @@ from plistsync.services.registry import Registry
 
 
 class SerialID(ABC):
-    """Immutable base for identifiers with a canonical, namespaced serial form."""
+    """Immutable base for identifiers with a canonical, namespace-prefixed serial."""
 
     @classmethod
     @abstractmethod
@@ -48,8 +48,8 @@ class SerialID(ABC):
         if "services" in parts:
             return parts[parts.index("services") + 1]
         raise ValueError(
-            f"Cannot infer namespace from module {cls.__module__!r}; "
-            f"override {cls.__name__}.namespace()"
+            f"Cannot infer namespace prefix from module {cls.__module__!r}; "
+            f"override {cls.__name__}.prefix()"
         )
 
     def __post_init__(self) -> None:
@@ -106,23 +106,6 @@ class PlaylistID(SerialID, ABC, Registry):
                 f"Invalid playlist serial {serial!r}, cannot parse service name"
             )
             return None
-
-        # We have some global track identifiers that are not tied to a
-        # specific service. This is a bit awkward maybe sync should be a service
-        from plistsync.core.sync import SyncedPlaylistID
-
-        global_service_identifier: dict[str, type[PlaylistID]] = {
-            "sync": SyncedPlaylistID,
-        }
-        if service_name in global_service_identifier:
-            try:
-                return global_service_identifier[service_name].parse(serial)
-            except ValueError:
-                log.warning(
-                    f"Invalid global playlist identifier {serial!r} for"
-                    f" service {service_name!r}"
-                )
-                return None
 
         service = ServiceLoader.get(service_name)
         if not service:

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -5,26 +7,13 @@ from enum import Enum
 from pathlib import PurePath
 from typing import ClassVar, Self
 
+from plistsync.logger import log
+from plistsync.services import ServiceLoader
 from plistsync.services.registry import Registry
 
 
-@dataclass(frozen=True)
-class PlaylistID(ABC, Registry):
-    """Immutable base for service-specific playlist identifiers.
-
-    Decouples the service-specific representation from the generic playlist
-    management logic.
-
-    Should contain a unique identifier for a playlist
-    within a specific service.
-    Should not be passed down to the API layer of a service.
-    There, the native, service-specific representation should be used,
-    e.g. a simple `id` string for spotify, or the int `id` for plex.
-
-    We need this abstraction to allow us to load and save playlists in a generic
-    way i.e. to implement the loading logic only once but have it work for
-    all services.
-    """
+class SerialID(ABC):
+    """Immutable base for identifiers with a canonical, namespaced serial form."""
 
     @classmethod
     @abstractmethod
@@ -47,6 +36,39 @@ class PlaylistID(ABC, Registry):
         """
         raise NotImplementedError
 
+    @classmethod
+    def prefix(cls) -> str:
+        """Prefix, inferred from the module path.
+
+        Should be unique! Defaults to the first part of the module path
+        after ``plistsync.services`` i.e. ``plistsync.services.<name>.*``
+        get ``<name>``. Classes outside a service module must override this.
+        """
+        parts = cls.__module__.split(".")
+        if "services" in parts:
+            return parts[parts.index("services") + 1]
+        raise ValueError(
+            f"Cannot infer namespace from module {cls.__module__!r}; "
+            f"override {cls.__name__}.namespace()"
+        )
+
+    def __post_init__(self) -> None:
+        """Enforce that ``serial`` starts with the namespace prefix.
+
+        Skipped when the namespace cannot be inferred (e.g. test doubles).
+        Subclasses with a custom ``__init__`` or ``__post_init__`` bypass this
+        check entirely; the serial round-trip tests guard those.
+        """
+        try:
+            expected = type(self).prefix() + ":"
+        except ValueError:
+            return
+        if not self.serial.startswith(expected):
+            raise ValueError(
+                f"{type(self).__name__}.serial must start with {expected!r}, "
+                f"got {self.serial!r}"
+            )
+
     def __repr__(self) -> str:
         return f"{type(self).__name__}(serial={self.serial!r})"
 
@@ -61,49 +83,112 @@ class Scope(Enum):
     LOCAL = "local"
 
 
-@dataclass(frozen=True)
-class TrackID(ABC, Registry):
-    """Immutable base for service-specific track identifiers.
+@dataclass(frozen=True, repr=False)
+class PlaylistID(SerialID, ABC, Registry):
+    """Immutable base for playlist identifiers (serial: ``<service>:playlist:<id>``)."""
 
-    Decouples the service-specific representation from the generic track
-    management logic.
+    @classmethod
+    def prefix(cls) -> str:
+        return f"{super().prefix()}:playlist"
 
-    Should contain a unique identifier for a track
-    within a specific service.
-    Should not be passed down to the API layer of a service.
-    There, the native, service-specific representation should be used,
-    e.g. a simple `id` string for spotify, or the int `id` for plex.
+    @classmethod
+    def from_serial(cls, serial: str) -> PlaylistID | None:
+        """Load from a serial string (``<service>:playlist:<payload>``).
 
-    We need this abstraction to allow us to load and save tracks in a generic
-    way i.e. to implement the loading logic only once but have it work for
-    all services.
-    """
+        This is a convenience method to parse a serial string into the correct
+        subclass of :class:`PlaylistID` for the service. Returns ``None`` if the
+        service is not available or no matching identifier class is found.
+        """
+        try:
+            service_name = serial.split(":", 1)[0]
+        except IndexError:
+            log.warning(
+                f"Invalid playlist serial {serial!r}, cannot parse service name"
+            )
+            return None
+
+        service = ServiceLoader.get(service_name)
+        if not service:
+            log.warning(
+                f"Service {service_name!r} not available for playlist serial {serial!r}"
+            )
+            return None
+
+        for pid_cls in service.playlist_ids():
+            # Check if prefix matches
+            if pid_cls.prefix().startswith(service_name):
+                try:
+                    return pid_cls.parse(serial)
+                except ValueError:
+                    continue
+
+        log.info(
+            f"No playlist identifier class found for serial {serial!r}"
+            f" in service {service_name!r}"
+        )
+        return None
+
+
+@dataclass(frozen=True, repr=False)
+class TrackID(SerialID, ABC, Registry):
+    """Immutable base for track identifiers (serial: ``<service>:track:<id>``)."""
 
     scope: ClassVar[Scope] = Scope.GLOBAL
 
     @classmethod
-    @abstractmethod
-    def parse(cls, value: str) -> Self:
-        """Parse from user input (URL, URI, or raw id)."""
-        raise NotImplementedError
+    def prefix(cls) -> str:
+        return f"{super().prefix()}:track"
 
-    @property
-    @abstractmethod
-    def serial(self) -> str:
+    @classmethod
+    def from_serial(cls, serial: str) -> TrackID | None:
+        """Load from a serial string (``<service>:track:<payload>``).
+
+        This is a convenience method to parse a serial string into the correct
+        subclass of :class:`TrackID` for the service. Returns ``None`` if the
+        service is not available or no matching identifier class is found.
         """
-        Plistsync's internal string-representation of service specific track ID.
+        try:
+            service_name = serial.split(":", 1)[0]
+        except IndexError:
+            log.warning(f"Invalid track serial {serial!r}, cannot parse service name")
+            return None
 
-        By convention it should look like `service_name:your_custom:format` e.g.
-        `spotify:track:actual_id`. This is not enforced but recommended.
+        # We have some global track identifiers that are not tied to a
+        # specific service.
+        global_service_identifier: dict[str, type[TrackID]] = {
+            "isrc": ISRC,
+            "file": FilePath,
+        }
+        if service_name in global_service_identifier:
+            try:
+                return global_service_identifier[service_name].parse(serial)
+            except ValueError:
+                log.warning(
+                    f"Invalid global track identifier {serial!r} for"
+                    f" service {service_name!r}"
+                )
+                return None
 
-        By convention, to get the _canonical_ representation that the service API
-        understands, you should define `__str__` or `__int__` methods to get the
-        shorter and convenient values.
-        """
-        raise NotImplementedError
+        service = ServiceLoader.get(service_name)
+        if not service:
+            log.warning(
+                f"Service {service_name!r} not available for track serial {serial!r}"
+            )
+            return None
 
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}(serial={self.serial!r})"
+        for tid_cls in service.track_ids():
+            # Check if prefix matches
+            if tid_cls.prefix().startswith(service_name):
+                try:
+                    return tid_cls.parse(serial)
+                except ValueError:
+                    continue
+
+        log.info(
+            f"No track identifier class found for serial {serial!r}"
+            f" in service {service_name!r}"
+        )
+        return None
 
 
 # Commonly shared IDS
@@ -127,6 +212,10 @@ class ISRC(TrackID, service="core"):
         object.__setattr__(self, "id", normalised)
 
     @classmethod
+    def prefix(cls) -> str:
+        return "isrc"
+
+    @classmethod
     def parse(cls, value: str) -> Self:
         """Parse from user input (URL, URI, serial, or raw id).
 
@@ -134,8 +223,8 @@ class ISRC(TrackID, service="core"):
         (``isrc:XXAAA0000000``), or the dashed format (``XX-AAA-00-00000``).
         """
         value = value.strip()
-        if value.lower().startswith("isrc:"):
-            value = value[5:]
+        if value.lower().startswith(cls.prefix()):
+            value = value[len(cls.prefix()) + 1 :]
         # __init__ handles dash-stripping and uppercasing
         if not re.fullmatch(
             r"[A-Z]{2}[A-Z0-9]{3}\d{7}", value.replace("-", "").upper()
@@ -146,7 +235,7 @@ class ISRC(TrackID, service="core"):
     @property
     def serial(self) -> str:
         """Plistsync's internal string-representation of ISRC."""
-        return f"isrc:{self.id}"
+        return f"{self.prefix()}:{self.id}"
 
     def __str__(self) -> str:
         """Compact display (just the raw id)."""
@@ -167,17 +256,21 @@ class FilePath(TrackID, service="core"):
     """The filesystem path to the track file."""
 
     @classmethod
+    def prefix(cls) -> str:
+        return "file"
+
+    @classmethod
     def parse(cls, value: str) -> Self:
         """Parse from user input (raw path or serial ``file:...`` format)."""
         value = value.strip()
-        if value.lower().startswith("file:"):
-            value = value[5:]
+        if value.lower().startswith(cls.prefix()):
+            value = value[len(cls.prefix()) + 1 :]
         return cls(PurePath(value))
 
     @property
     def serial(self) -> str:
         """Plistsync's internal string-representation of the file path."""
-        return f"file:{self.path.as_posix()}"
+        return f"{self.prefix()}:{self.path.as_posix()}"
 
     def __str__(self) -> str:
         """Compact display (just the raw path string)."""

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -107,6 +107,23 @@ class PlaylistID(SerialID, ABC, Registry):
             )
             return None
 
+        # We have some global track identifiers that are not tied to a
+        # specific service. This is a bit awkward maybe sync should be a service
+        from plistsync.core.sync import SyncedPlaylistID
+
+        global_service_identifier: dict[str, type[PlaylistID]] = {
+            "sync": SyncedPlaylistID,
+        }
+        if service_name in global_service_identifier:
+            try:
+                return global_service_identifier[service_name].parse(serial)
+            except ValueError:
+                log.warning(
+                    f"Invalid global playlist identifier {serial!r} for"
+                    f" service {service_name!r}"
+                )
+                return None
+
         service = ServiceLoader.get(service_name)
         if not service:
             log.warning(

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -5,9 +5,11 @@ from enum import Enum
 from pathlib import PurePath
 from typing import ClassVar, Self
 
+from plistsync.services.registry import Registry
+
 
 @dataclass(frozen=True)
-class PlaylistID(ABC):
+class PlaylistID(ABC, Registry):
     """Immutable base for service-specific playlist identifiers.
 
     Decouples the service-specific representation from the generic playlist
@@ -60,7 +62,7 @@ class Scope(Enum):
 
 
 @dataclass(frozen=True)
-class TrackID(ABC):
+class TrackID(ABC, Registry):
     """Immutable base for service-specific track identifiers.
 
     Decouples the service-specific representation from the generic track
@@ -108,7 +110,7 @@ class TrackID(ABC):
 
 
 @dataclass(frozen=True)
-class ISRC(TrackID):
+class ISRC(TrackID, service="core"):
     """International Standard Recording Code.
 
     A standardized identifier intended to be globally unique for a recording.
@@ -152,7 +154,7 @@ class ISRC(TrackID):
 
 
 @dataclass(frozen=True)
-class FilePath(TrackID):
+class FilePath(TrackID, service="core"):
     """File path identifier for local tracks.
 
     This is a simple wrapper around a file path, used to identify local tracks in a

--- a/plistsync/core/matching.py
+++ b/plistsync/core/matching.py
@@ -8,15 +8,20 @@ similarity scores, and handling different types of metadata such as strings and 
 from __future__ import annotations
 
 import itertools
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from Levenshtein import ratio as levenshtein_ratio
 
 from plistsync.logger import log
 
-from .track import Track, TrackInfo
+from .track import Track
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
+    from .track import TrackInfo
 
 Similarity = float
 
@@ -110,7 +115,7 @@ def distance(a: str | list[str], b: str | list[str]) -> float | None:
     a_seq = isinstance(a, Sequence)
     b_seq = isinstance(b, Sequence)
 
-    if a_seq and b_seq and len(a) == 0 or len(b) == 0:
+    if (a_seq and b_seq and len(a) == 0) or len(b) == 0:
         return None
 
     if a == b:

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -299,7 +299,7 @@ class MultiRequestServicePlaylist(ServicePlaylist[T], ABC):
         if new_name is not None or new_description is not None:
             self._remote_update_metadata(new_name, new_description)
 
-        operations = list_diff(before.tracks, after.tracks, hash_func=self._track_key)
+        operations = list_diff(before.tracks, after.tracks, key_func=self._track_key)
         for batch in batch_consecutive(operations.iter()):
             # Batch is always nonempty batch of operation
             # including consecutive indexes

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -20,20 +20,24 @@ the required methods.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Hashable, Sequence
 from contextlib import contextmanager
 from copy import copy, deepcopy
 from dataclasses import dataclass
-from typing import Generic, Self, TypedDict
+from typing import TYPE_CHECKING, Generic, Self, TypedDict
 
 from typing_extensions import TypeVar
 
 from plistsync.services.registry import Registry
 
-from .collection import Collection, Library, TrackStream
+from .collection import Collection, TrackStream
 from .diff import DeleteOp, InsertOp, MoveOp, batch_consecutive, list_diff
-from .ids import PlaylistID
 from .track import OfflineTrack, Track
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Sequence
+
+    from .collection import Library
+    from .ids import PlaylistID
 
 
 class PlaylistInfo(TypedDict, total=False):
@@ -403,14 +407,14 @@ class MultiRequestServicePlaylist(ServicePlaylist[T], ABC):
             tracks_before=tracks_before,
         )
         tracks_before.pop(old_idx)
-        # Insert at new position (note: new_idx may have shifted due to pop)
-        adjusted_new_idx = new_idx if new_idx > old_idx else new_idx
+        # new_idx is the index in the list *after* the move (see MoveOp),
+        # which is exactly the insert position once the track is removed.
         self._remote_insert_track(
-            idx=adjusted_new_idx,
+            idx=new_idx,
             track=track,
             tracks_before=tracks_before,
         )
-        tracks_before.insert(adjusted_new_idx, track)
+        tracks_before.insert(new_idx, track)
 
     @abstractmethod
     def _remote_update_metadata(

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -454,46 +454,29 @@ class OfflinePlaylist(Playlist[OfflineTrack], service="core"):
 
     _tracks: list[OfflineTrack]
     _info: PlaylistInfo
-    _id_serial: str
+    _id: PlaylistID
 
     def __init__(
         self,
-        id_serial: str,
+        id: PlaylistID,
         info: PlaylistInfo,
         tracks: Sequence[OfflineTrack] | None = None,
     ) -> None:
         self._info = info
         self._tracks = list(tracks or [])
-        self._id_serial = id_serial
+        self._id = id
 
     @classmethod
     def from_playlist(cls, playlist: Playlist) -> OfflinePlaylist:
         return OfflinePlaylist(
-            id_serial=playlist.id.serial,
+            id=playlist.id,
             info=copy(playlist.info),
             tracks=[OfflineTrack.from_track(t) for t in playlist.tracks],
         )
 
     @property
     def id(self) -> PlaylistID:
-        """PlaylistID retreived from serializid string."""
-
-        from plistsync.services import ServiceRegistry
-
-        colon_idx = self._id_serial.find(":")
-        if colon_idx == -1:
-            raise ValueError(
-                f"Cannot determine service for serial: {self._id_serial!r}"
-            )
-        service_str = self._id_serial[:colon_idx]
-
-        if not (service := ServiceRegistry.get(service_str)):
-            raise ValueError(f"Unknown service {service!r} in OfflinePlaylistID")
-
-        if not (playlist_id_cls := service.playlist_id_cls):
-            raise ValueError(f"Service {service!r} has no PlalistID class registered")
-
-        return playlist_id_cls.parse(self._id_serial)
+        return self._id
 
     @property
     def info(self) -> PlaylistInfo:

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -28,6 +28,8 @@ from typing import Generic, Self, TypedDict
 
 from typing_extensions import TypeVar
 
+from plistsync.services.registry import Registry
+
 from .collection import Collection, Library, TrackStream
 from .diff import DeleteOp, InsertOp, MoveOp, batch_consecutive, list_diff
 from .ids import PlaylistID
@@ -68,7 +70,7 @@ class Snapshot(Generic[T]):
     tracks: list[T]
 
 
-class Playlist(Generic[T], Collection[T], TrackStream[T], ABC):
+class Playlist(Generic[T], Collection[T], TrackStream[T], ABC, Registry):
     """Abstract base class defining the core playlist interface.
 
     This class provides a minimal protocol for playlist-like objects without
@@ -441,7 +443,7 @@ class MultiRequestServicePlaylist(ServicePlaylist[T], ABC):
 # TODO: We should move this into another file
 
 
-class OfflinePlaylist(Playlist[OfflineTrack]):
+class OfflinePlaylist(Playlist[OfflineTrack], service="core"):
     """A offline (in memory) playlist with no service synchronization.
 
     This class provides a concrete implementation of `Playlist` for

--- a/plistsync/core/rewrite.py
+++ b/plistsync/core/rewrite.py
@@ -32,7 +32,7 @@ class PathRewrite(NamedTuple):
 
     def _coerce_like(self, template: T, p: PurePath) -> T:
         """Coerce `p` into the same concrete path class as `template`."""
-        path_cls = cast(type[T], template.__class__)
+        path_cls = cast("type[T]", template.__class__)
         return path_cls(str(p))
 
     def apply(self, path: T) -> T:
@@ -58,4 +58,4 @@ class PathRewrite(NamedTuple):
         return PathRewrite(self.new, self.old)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(old='{str(self.old)}', new='{str(self.new)}')"
+        return f"{type(self).__name__}(old='{self.old!s}', new='{self.new!s}')"

--- a/plistsync/core/sync/__init__.py
+++ b/plistsync/core/sync/__init__.py
@@ -1,0 +1,11 @@
+"""Synchronisation primitives for cross-service playlist management."""
+
+from plistsync.core.sync.playlist import (
+    SyncedPlaylist,
+    SyncedPlaylistID,
+)
+
+__all__ = [
+    "SyncedPlaylist",
+    "SyncedPlaylistID",
+]

--- a/plistsync/core/sync/playlist.py
+++ b/plistsync/core/sync/playlist.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
+
+from plistsync.core import PlaylistID
+from plistsync.core.crdt import Fugue, LWWRegister
+from plistsync.core.diff import DeleteOp as DiffDeleteOp
+from plistsync.core.diff import InsertOp as DiffInsertOp
+from plistsync.core.diff import MoveOp as DiffMoveOp
+from plistsync.core.diff import list_diff_eq
+from plistsync.core.playlist import (
+    Playlist,
+    PlaylistInfo,
+)
+from plistsync.core.track import OfflineTrack
+from plistsync.logger import log
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from plistsync.core import Track
+    from plistsync.core.crdt import DeleteOp as CRDTDeleteOp
+    from plistsync.core.crdt import InsertOp as CRDTInsertOp
+    from plistsync.core.crdt import RegisterOp
+    from plistsync.core.playlist import (
+        ServicePlaylist,
+    )
+
+ReplicaID = int
+
+
+@dataclass
+class _TrackLink:
+    """Helper to associate tracks with multiple service-specific playlists.
+
+    This is a wrapper around :class:`OfflineTrack` that hold references to the playlists
+    across services to which this tracks belongs.
+
+    However, even if a track holds a reference to a service playlist, it is not
+    guaranteed, that the track is still in this playlist (it might have been in
+    that playlist once, and now has been removed).
+    """
+
+    track: OfflineTrack
+    playlists: set[PlaylistID]
+
+
+@dataclass(frozen=True)
+class SyncedPlaylistID(PlaylistID, service="core"):
+    """Unique identifier for a synced playlist."""
+
+    id: UUID
+
+    @classmethod
+    def prefix(cls) -> str:
+        return "sync:playlist"
+
+    @classmethod
+    def new(cls) -> SyncedPlaylistID:
+        """Generate a new unique ID for a synced playlist."""
+        return cls(uuid4())
+
+    @classmethod
+    def parse(cls, value: str) -> SyncedPlaylistID:
+        """Parse from a string representation of a UUID."""
+
+        if value.startswith(cls.prefix()):
+            value = value[len(cls.prefix()) + 1 :]
+        return cls(UUID(value))
+
+    @property
+    def serial(self) -> str:
+        """Plistsync's internal representation (here matches canonical UUID)."""
+        return f"{self.prefix()}:{self.id!s}"
+
+    def __str__(self) -> str:
+        """Compact display (just the raw UUID)."""
+        return str(self.id)
+
+
+class SyncedPlaylist(Playlist[OfflineTrack], service="core"):
+    """Orchestrates cross-service playlist sync.
+
+    Holds a :class:`Fugue` of :class:`_TrackLink` objects.
+    The fugue is as the operation history, while the tracklinks
+
+
+    TODO: Fixup/remove this and move it into the docs
+    Concepts:
+    - internal playlist:
+        - ground truth of the playlist, with all tracks
+          (independent of service availability)
+        - determined by going through all operatioins of the fugue
+        - think of it as the latest service-agnostic playlists that is
+          derivable from the changelog
+    - linked playlist:
+        - service-specific reference to the internal playlist
+        - may only contain a subset of all tracks of the interal playlist,
+          i.e. if a track is missing from this particular service.
+        - if sync worked, all tracks avaialable, pretty much a copy of internal playlist
+          (or projection into the service)
+    - fugue
+        - think "history of track operations":
+        - holds _tracklinks_ and their operation-history (op-history is append only)
+        - crdt data-structure that holds operations and works regardless of their
+          order (but still produces a correctly ordered internal playlist)
+    - tracklinks
+        - make the connection between a service-spanning track and the
+          linked playlists on services.
+    - fork and replica:
+        - here pretty synonymous (only distinction is where is it located / kept)
+        - a replica is a copy of the fugue that may receive different changes
+          than other replicas (think git fork)
+        - replicas can be merged _without_ conflicts via crdt
+    """
+
+    _fugue: Fugue[_TrackLink]
+
+    _id: SyncedPlaylistID
+    _info: LWWRegister
+
+    # Replica ID -> linked playlist ID mapping. Each linked playlist is a sync target.
+    _linked_playlists: dict[ReplicaID, ServicePlaylist]
+
+    def __init__(
+        self,
+        name: str,
+        description: str | None = None,
+        tracks: Sequence[OfflineTrack] | None = None,
+    ) -> None:
+        """Initialize a new SyncedPlaylist."""
+        self._info = LWWRegister()
+        self._info.assign("name", name)
+        self._info.assign("description", description)
+        self._linked_playlists = {}
+        self._fugue = Fugue()
+        self._id = SyncedPlaylistID.new()
+
+        # Initialize from tracks
+        for i, track in enumerate(tracks or []):
+            self._fugue.insert(i, _TrackLink(track=track, playlists=set()))
+
+    # ----------------------- Required (Playlist protocol) ----------------------- #
+
+    def _new_replica_id(self) -> ReplicaID:
+        """Generate a new replica ID which isn't used yet."""
+        return max([*list(self._linked_playlists.keys()), 0]) + 1
+
+    @property
+    def info(self) -> PlaylistInfo:
+        return PlaylistInfo(**dict(self._info))  # type: ignore[typeddict-item]
+
+    @info.setter
+    def info(self, value: PlaylistInfo) -> None:
+        for field, field_value in value.items():
+            self._info.assign(field, field_value)
+
+    @property
+    def tracks(self) -> list[OfflineTrack]:
+        return list(map(lambda t: t.track, self._fugue))
+
+    @tracks.setter
+    def tracks(self, value: Sequence[OfflineTrack]) -> None:
+        raise NotImplementedError(
+            "Directly setting tracks is not supported; use sync() instead."
+        )
+
+    @property
+    def id(self) -> SyncedPlaylistID:
+        return self._id
+
+    # ------------------------------- Sync specific ------------------------------ #
+
+    def register(self, playlist: ServicePlaylist) -> None:
+        """Register a playlist as a synchronization target.
+
+        Existing tracks from the playlist are added to the internal collection.
+        Tracks already in the internal collection but missing from the playlist
+        are preserved.
+
+        Name and description from the playlist are not used; the internal state is
+        authoritative. Use :meth:`sync` to push the internal state back to the playlist.
+        """
+        replica_id = self._new_replica_id()
+        self._linked_playlists[replica_id] = playlist
+
+        if playlist.tracks:
+            # Use a fork here so operations carry the new replica ID for versioning.
+            fork = self._fugue.fork(replica_id)
+            for track in playlist.tracks:
+                op = fork.insert(
+                    len(fork),
+                    _TrackLink(
+                        track=OfflineTrack.from_track(track), playlists={playlist.id}
+                    ),
+                )
+                self._fugue.apply(op)
+
+        self._enrich_internal_from(playlist)
+        self._push_internal_to(playlist)
+
+    def sync(self) -> None:
+        """Synchronize linked playlists with the internal track collection.
+
+        Refreshes linked playlists, merges external changes, enriches tracks with
+        missing metadata, and pushes the resulting collection back to linked
+        playlists.
+        """
+        # Get current playlist contents from services
+        self.refresh()
+        # Reconcile playlist changes into the Fugue (CRDT operations)
+        self.merge()
+        # Extend the internal state and match tracks between the playlists.
+        self.enrich()
+        # Push the updated internal state back to all linked playlists.
+        self.push()
+
+    def refresh(self) -> None:
+        """Refresh linked playlists from their services.
+
+        Fetches the current playlist contents to include changes made outside
+        this library.
+        """
+        for replica_id, playlist in self._linked_playlists.items():
+            self._linked_playlists[replica_id] = playlist.library.get_playlist_or_raise(
+                id=playlist.id
+            )
+
+    def merge(self) -> None:
+        """Merge changes from linked playlists into the internal collection.
+
+        Reconciles both track membership (via the Fugue) and playlist
+        metadata such as name/description (via the info register).
+        """
+        track_ops: list[CRDTInsertOp[_TrackLink] | CRDTDeleteOp] = []
+        info_ops: list[RegisterOp[Any]] = []
+        for replica_id, playlist in self._linked_playlists.items():
+            for op in self._playlist_diff_ops(replica_id, playlist):
+                track_ops.append(op)
+            for op in self._info_diff_ops(replica_id, playlist):
+                info_ops.append(op)
+
+        for track_op in track_ops:
+            self._fugue.apply(track_op)
+        for info_op in info_ops:
+            self._info.apply(info_op)
+
+    def _info_diff_ops(
+        self, replica_id: int, playlist: ServicePlaylist
+    ) -> Iterable[RegisterOp[Any]]:
+        """Produce register ops to reconcile *playlist*'s info with a fork.
+
+        As for the track diff, an op is only produced for fields that
+        actually changed on the service since this replica's last write, so
+        unchanged playlists never clobber newer values from other replicas.
+        An explicit None counts as a change (clearing e.g. a description);
+        fields *absent* from the playlist's info are left untouched, as they
+        may be unsupported by the service and the register has no deletion
+        semantics.
+        """
+        fork = self._info.fork(replica_id)
+        for field, value in playlist.info.items():
+            last = self._info.last_op_by(field, replica_id)
+            if last is None or last.value != value:
+                yield fork.assign(field, value)
+
+    def _playlist_diff_ops(
+        self, replica_id: int, playlist: ServicePlaylist
+    ) -> Iterable[CRDTInsertOp[_TrackLink] | CRDTDeleteOp]:
+        """Produce CRDT ops to reconcile *playlist* with a fork."""
+        fork = self._fugue.fork(replica_id)
+
+        # Check which tracks of the current service playlist are already in the fugue
+        # Projection for this playlist only, we skip tracks of all other playlists
+        old: list[OfflineTrack] = [
+            synced_track.track
+            for synced_track in fork
+            if playlist.id in synced_track.playlists
+        ]
+
+        new = [OfflineTrack.from_track(t) for t in playlist.tracks]
+        diff_ops = list_diff_eq(
+            old,
+            new,
+            # We compare via intersection of the IDs, as the same track may have
+            # different subsets of the "true"
+            eq_func=lambda t1, t2: bool(t1.ids & t2.ids),
+        )
+
+        for step in diff_ops.iter():
+            op = step.op
+            if isinstance(op, DiffInsertOp):
+                yield fork.insert(
+                    op.idx, _TrackLink(track=op.item, playlists={playlist.id})
+                )
+            elif isinstance(op, DiffDeleteOp):
+                yield fork.delete(op.idx)
+            elif isinstance(op, DiffMoveOp):
+                yield fork.delete(op.old_idx)
+                yield fork.insert(
+                    op.new_idx, _TrackLink(track=op.item, playlists={playlist.id})
+                )
+
+    def enrich(self) -> None:
+        """Enrich tracks with IDs and playlist associations from linked playlists.
+
+        This is a one-way operation that updates the internal track collection
+        based on the contents of the linked playlists. It does not push changes
+        back to the linked playlists.
+        """
+
+        for playlist in self._linked_playlists.values():
+            self._enrich_internal_from(playlist)
+
+    def _enrich_internal_from(self, playlist: ServicePlaylist):
+        """Enrich the internal track collection from a linked playlist."""
+
+        for linked_track in self._fugue:
+            if playlist.id not in linked_track.playlists:
+                # Search in playlist first. This is faster than searching in library
+                match = playlist.match(linked_track.track)
+                if match.best_match is None:
+                    match = playlist.library.match(linked_track.track)
+
+                if match.best_match is not None:
+                    linked_track.track.enrich(match.best_match.ids)
+                    linked_track.playlists.add(playlist.id)
+
+    def push(self) -> None:
+        """Update linked playlists from the internal track collection.
+
+        Resolves tracks for each service and aligns their playlist contents.
+        """
+
+        for playlist in self._linked_playlists.values():
+            self._push_internal_to(playlist)
+
+    def _push_internal_to(self, playlist: ServicePlaylist[Track]) -> None:
+        """Update a linked playlist from the internal track collection.
+
+        Aligns the playlist's tracks with the resolved internal tracks.
+        """
+
+        new_tracks: list[Track] = []
+        for linked_track in self._fugue:
+            if playlist.id in linked_track.playlists:
+                # Search in playlist first. This is faster than searching in library
+                match = playlist.match(linked_track.track)
+                if match.best_match is None:
+                    match = playlist.library.match(linked_track.track)
+
+                if match.best_match is None:
+                    log.warning(
+                        f"Track {linked_track.track} not found in {playlist.id}; "
+                        "removing playlist association"
+                    )
+                    linked_track.playlists.remove(playlist.id)
+                else:
+                    new_tracks.append(match.best_match)
+
+        with playlist.edit():
+            playlist.tracks = new_tracks

--- a/plistsync/core/sync/playlist.py
+++ b/plistsync/core/sync/playlist.py
@@ -48,7 +48,7 @@ class _TrackLink:
 
 
 @dataclass(frozen=True)
-class SyncedPlaylistID(PlaylistID, service="core"):
+class SyncedPlaylistID(PlaylistID, service="sync"):
     """Unique identifier for a synced playlist."""
 
     id: UUID
@@ -209,7 +209,7 @@ class SyncedPlaylist(Playlist[OfflineTrack], service="core"):
         playlists.
         """
         # Get current playlist contents from services
-        self.refresh()
+        self.fetch()
         # Reconcile playlist changes into the Fugue (CRDT operations)
         self.merge()
         # Extend the internal state and match tracks between the playlists.
@@ -217,7 +217,7 @@ class SyncedPlaylist(Playlist[OfflineTrack], service="core"):
         # Push the updated internal state back to all linked playlists.
         self.push()
 
-    def refresh(self) -> None:
+    def fetch(self) -> None:
         """Refresh linked playlists from their services.
 
         Fetches the current playlist contents to include changes made outside

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -194,6 +194,15 @@ class OfflineTrack(Track, service="core"):
 
         return OfflineTrack(info, ids)
 
+    def enrich(self, ids: Iterable[TrackID]) -> None:
+        """Add *ids* to this track in-place (mutates ``self.ids``).
+
+        Safe to call on tracks stored inside a :class:`Fugue` —
+        the Fugue holds objects by reference, so the enrichment
+        is visible to all future reads.
+        """
+        self._ids = self._ids | frozenset(ids)
+
     @classmethod
     def from_track(cls, track: Track) -> OfflineTrack:
         """Create a offline track from arbitrary other track."""

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 
 from plistsync.core.ids import ISRC, FilePath, TrackID
 from plistsync.logger import log
+from plistsync.services.registry import Registry
 
 
 class TrackInfo(TypedDict, total=False):
@@ -27,7 +28,7 @@ class TrackInfo(TypedDict, total=False):
     # convention, likely close to beets.
 
 
-class Track(ABC):
+class Track(ABC, Registry):
     """An abstract class representing a track.
 
     A track is a piece of music. It has a title, artists, albums and identifiers.
@@ -148,7 +149,7 @@ class Track(ABC):
         return f"{cls}(artist={artist!r}, title={title!r})"
 
 
-class OfflineTrack(Track):
+class OfflineTrack(Track, service="core"):
     """A offline (in memory) track with attached service.
 
     This class provides a concrete implementation of `Track` for

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
 from copy import copy
-from pathlib import PurePath
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
-from plistsync.core.ids import ISRC, FilePath, TrackID
+from plistsync.core.ids import ISRC, FilePath
 from plistsync.logger import log
 from plistsync.services.registry import Registry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import PurePath
+
+    from plistsync.core.ids import TrackID
 
 
 class TrackInfo(TypedDict, total=False):

--- a/plistsync/errors.py
+++ b/plistsync/errors.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 
 from eyconf.validation import ConfigurationError, MultiConfigurationError
 
@@ -57,12 +57,12 @@ def check_imports(
             package.split("[")[0].split("<")[0].split(">")[0].split("=")[0].strip()
         )
 
-        try:
-            importlib.import_module(base_package)
-        except ImportError:
+        if importlib.util.find_spec(base_package) is None:
             missing.append(package)
 
     if missing:
         raise DependencyError(
-            service=service, missing_packages=missing, extra_name=extra_name
+            service=service,
+            missing_packages=missing,
+            extra_name=extra_name,
         )

--- a/plistsync/services/__init__.py
+++ b/plistsync/services/__init__.py
@@ -1,81 +1,114 @@
 # We do not import from the different submodules as they
 # might raise with check_dependencies.
 
-import importlib
-import inspect
-import pkgutil
-from abc import ABC
-from functools import cache
-from typing import ClassVar
+from __future__ import annotations
 
-from plistsync.core import Library, Playlist, PlaylistID, Track
+from abc import ABC
+from collections.abc import Sequence
+from functools import cache
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
 from plistsync.errors import DependencyError
 
+from .registry import Registry
 
-class Service(ABC):
+if TYPE_CHECKING:
+    from plistsync.core import Library, Track
+    from plistsync.core.ids import PlaylistID, TrackID
+
+
+class Service(ABC, Registry):
     """Abstraction for discoverable service plugins.
 
-    Subclasses in `services/<name>/` modules are automatically
-    discovered by the ServiceRegistry.
+    Concrete service implementations register their identifier classes at
+    class-definition time. Importing a service module is sufficient to make
+    its classes discoverable.
 
-    Each concrete Service exposes the key types that belong to its
-    service: the library/collection class and the track class.
-    Optionally a playlist class for playlist-capable services.
+    Each service exposes the identifier classes associated with it, including
+    track identifiers and optionally playlist identifiers.
     """
-
-    track_cls: ClassVar[type[Track]]
-    library_cls: ClassVar[type[Library] | None] = None
-    playlist_cls: ClassVar[type[Playlist] | None] = None
-    playlist_id_cls: ClassVar[type[PlaylistID] | None] = None
 
     @property
     def name(self) -> str:
         """Service name, inferred from the module (e.g. 'spotify', 'plex')."""
         return self.__module__.split(".")[-1]
 
+    def playlist_ids(self) -> Sequence[type[PlaylistID]]:
+        """Return playlist identifier classes registered for this service."""
 
-class ServiceRegistry:
-    """Central registry for dynamic service discovery and instantiation.
+        from plistsync.core.ids import PlaylistID
 
-    Automatically discovers Service subclasses in services/* modules
-    using pkgutil + importlib. Lazy-loaded with @cache for performance.
-    Handles missing dependencies gracefully.
+        return PlaylistID.registry().get(self.name, ())
 
-    Usage:
-        >>> service = ServiceRegistry.get_service('spotify')
-        >>> services = ServiceRegistry.list()  # {'spotify': SpotifyService(), ...}
+    def track_ids(self) -> Sequence[type[TrackID]]:
+        """Return track identifier classes registered for this service."""
+
+        from plistsync.core.ids import TrackID
+
+        return TrackID.registry().get(self.name, ())
+
+    def library(self) -> type[Library] | None:
+        """Return the library class registered for this service, if any."""
+        from plistsync.core import Library
+
+        return Library.registry().get(self.name, (None,))[0]
+
+    def tracks(self) -> Sequence[type[Track]]:
+        """Return the track class registered for this service, if any."""
+        from plistsync.core import Track
+
+        return Track.registry().get(self.name, ())
+
+
+class ServiceLoader:
+    """Lazy access to discoverable services specific classes."""
+
+    GROUP = "plistsync.services"
+    """Entry point group for discoverable services. Defined in the pyproject.toml to
+    allow registering a service.
+
+    This improves discoverability and avoids importing service modules just to check if
+    they exist, which is pretty slow.
     """
 
     @classmethod
     @cache
     def get(cls, name: str) -> Service | None:
-        """Dynamically import services.NAME module, find Service ABC, instantiate."""
+        """Load and return a service by name.
+
+        Importing the service module triggers class registration. Returns
+        ``None`` if the service cannot be imported or no service class exists.
+        """
+        eps = entry_points(
+            group=cls.GROUP,
+            name=name,
+        )
+
+        if not eps:
+            return None
         try:
-            module = importlib.import_module(f"{__name__}.{name}")
+            service_cls = list(eps)[0].load()
         except (DependencyError, ModuleNotFoundError):
             return None
 
-        # Find first Service subclass (assumes 1/module)
-        service_cls: None | type[Service] = None
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if issubclass(obj, Service) and obj != Service:
-                service_cls = obj
-                break
-
-        return service_cls() if service_cls else None
+        return service_cls()
 
     @classmethod
     @cache
-    def dict(cls) -> dict[str, Service]:
-        """All importable services {name: instance}.
+    def all(cls) -> dict[str, Service]:
+        """Return a mapping of service names to service instances.
 
-        Scans services/* modules via pkgutil, filters valid ones.
+        This will import all available service modules to trigger registration.
         """
         services: dict[str, Service] = {}
-        # REQUIRES: ServiceRegistry in package with __path__ (services/__init__.py)
-        for module_info in pkgutil.iter_modules(__path__, __name__ + "."):
-            short_name = module_info.name.rsplit(".", 1)[-1]
-            service = cls.get(short_name)
-            if service is not None:
-                services[short_name] = service
+
+        for ep in entry_points(group=cls.GROUP):
+            try:
+                service_cls: type[Service] = ep.load()
+            except (DependencyError, ModuleNotFoundError):
+                continue
+
+            services[ep.name] = service_cls()
+
         return services

--- a/plistsync/services/__init__.py
+++ b/plistsync/services/__init__.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Sequence
 from functools import cache
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
@@ -14,7 +13,9 @@ from plistsync.errors import DependencyError
 from .registry import Registry
 
 if TYPE_CHECKING:
-    from plistsync.core import Library, Track
+    from collections.abc import Sequence
+
+    from plistsync.core import Library, Playlist, Track
     from plistsync.core.ids import PlaylistID, TrackID
 
 
@@ -60,6 +61,12 @@ class Service(ABC, Registry):
 
         return Track.registry().get(self.name, ())
 
+    def playlists(self) -> Sequence[type[Playlist]]:
+        """Return the playlist class registered for this service, if any."""
+        from plistsync.core import Playlist
+
+        return Playlist.registry().get(self.name, ())
+
 
 class ServiceLoader:
     """Lazy access to discoverable services specific classes."""
@@ -88,7 +95,7 @@ class ServiceLoader:
         if not eps:
             return None
         try:
-            service_cls = list(eps)[0].load()
+            service_cls = next(iter(eps)).load()
         except (DependencyError, ModuleNotFoundError):
             return None
 

--- a/plistsync/services/beets/__init__.py
+++ b/plistsync/services/beets/__init__.py
@@ -12,7 +12,7 @@ from .track import BeetsTrack
 
 
 class BeetsService(Service):
-    track_cls = BeetsTrack
+    pass
 
 
 __all__ = [

--- a/plistsync/services/beets/collection.py
+++ b/plistsync/services/beets/collection.py
@@ -1,15 +1,22 @@
-from collections.abc import Iterable
-from pathlib import Path, PurePath
-from typing import Any
+from __future__ import annotations
 
-from sqlalchemy import Row, String, cast, select
+from typing import TYPE_CHECKING, Any
 
-from plistsync.core import TrackID
+from sqlalchemy import String, cast, select
+
 from plistsync.core.collection import Collection, IDLookup, TrackStream
 from plistsync.core.ids import ISRC, FilePath
 
 from .database import BeetsDatabase
 from .track import BeetsTrack, BeetsTrackID
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path, PurePath
+
+    from sqlalchemy import Row
+
+    from plistsync.core import TrackID
 
 
 class BeetsCollection(Collection, TrackStream, IDLookup):
@@ -40,7 +47,7 @@ class BeetsCollection(Collection, TrackStream, IDLookup):
         table = self.db.get_table("items")
 
         stmt = select(table).filter(
-            cast(table.columns.path, String).like(f"%{str(path)}%")
+            cast(table.columns.path, String).like(f"%{path!s}%")
         )
         with self.db.session() as session:
             rows: Iterable[Any] = session.execute(stmt)

--- a/plistsync/services/beets/database.py
+++ b/plistsync/services/beets/database.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 import os
-from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from sqlalchemy import Engine, MetaData, Table, create_engine
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy import MetaData, Table, create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy import Engine
+    from sqlalchemy.orm import Session
 
 
 class BeetsDatabase:

--- a/plistsync/services/beets/track.py
+++ b/plistsync/services/beets/track.py
@@ -21,8 +21,8 @@ class BeetsTrackID(TrackID):
     def parse(cls, value: str) -> Self:
         """Parse from serial format or raw ID."""
         value = value.strip()
-        if value.lower().startswith("beets:"):
-            value = value[6:]
+        if value.lower().startswith(cls.prefix()):
+            value = value[len(cls.prefix()) + 1 :].strip()
         if not value.isdigit():
             raise ValueError(f"Invalid Beets track id: {value!r}")
         return cls(int(value))
@@ -30,7 +30,7 @@ class BeetsTrackID(TrackID):
     @property
     def serial(self) -> str:
         """Plistsync's internal representation for trackid on Beets."""
-        return f"beets:{self.id}"
+        return f"{self.prefix()}:{self.id}"
 
     def __str__(self) -> str:
         """Compact display, understood by Beets API."""

--- a/plistsync/services/local/__init__.py
+++ b/plistsync/services/local/__init__.py
@@ -11,7 +11,7 @@ from .track import LocalTrack
 
 
 class LocalService(Service):
-    track_cls = LocalTrack
+    pass
 
 
 __all__ = [

--- a/plistsync/services/local/collection.py
+++ b/plistsync/services/local/collection.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from plistsync.core import Collection, TrackID
+from plistsync.core import Collection
 from plistsync.core.collection import IDLookup
 
-from .track import FileCache, LocalTrack
+from .track import LocalTrack
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from plistsync.core import TrackID
+
+    from .track import FileCache
 
 
 class LocalCollection(Collection, IDLookup):

--- a/plistsync/services/local/track.py
+++ b/plistsync/services/local/track.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 from itertools import chain
-from pathlib import Path, PurePath
-from typing import cast
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from tinytag import TinyTag
 
-from plistsync.core import Collection, Track, TrackID
+from plistsync.core import Track
 from plistsync.core.collection import TrackStream
 from plistsync.core.ids import ISRC, FilePath
 from plistsync.core.track import TrackInfo
 
 from ...logger import log
+
+if TYPE_CHECKING:
+    from pathlib import PurePath
+
+    from plistsync.core import Collection, TrackID
 
 TagDict = dict[str, list[str] | str | float]
 
@@ -30,7 +35,7 @@ class FileCache:
     TODO: not sure if this is thread safe
     """
 
-    _file_cache: dict[Path, TagDict] = {}
+    _file_cache: ClassVar[dict[Path, TagDict]] = {}
 
     def __getitem__(self, path: Path) -> TagDict:
         if path not in self._file_cache:
@@ -70,7 +75,7 @@ class FileCache:
     def get_from_disk(path: Path) -> TagDict:
         """Get the metadata fresh from disk and update the cache for this track."""
 
-        meta = cast(TagDict, TinyTag.get(path).as_dict())
+        meta = cast("TagDict", TinyTag.get(path).as_dict())
 
         # tiny tag seems to have a lenghth one for many fields, extract!
         # and drop traktor4 cos it has a lot of data.
@@ -143,7 +148,7 @@ class LocalTrack(Track):
 
         isrc_raw = self.tags.get("isrc", [])
         if not isinstance(isrc_raw, list):
-            isrc_raw = [cast(str, isrc_raw)]
+            isrc_raw = [cast("str", isrc_raw)]
 
         # Sometimes the isrc is a list of isrcs
         if len(isrc_raw) > 0:

--- a/plistsync/services/plex/__init__.py
+++ b/plistsync/services/plex/__init__.py
@@ -13,10 +13,7 @@ from .track import PlexTrack, PlexTrackID
 
 
 class PlexService(Service):
-    library_cls = PlexLibrary
-    track_cls = PlexTrack
-    playlist_cls = PlexPlaylist
-    playlist_id_cls = PlexPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/plex/api.py
+++ b/plistsync/services/plex/api.py
@@ -7,11 +7,10 @@ happens on in the playlist.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import cache, cached_property
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import requests
@@ -21,14 +20,20 @@ from plistsync.utils.auth.bearer_token import InvalidTokenError, Token, TokenSes
 from plistsync.utils.session import PlistsyncSession
 
 from .api_types import (
-    PlexApiConnection,
-    PlexApiPlaylistResponse,
-    PlexApiPlaylistTrackResponse,
-    PlexApiResourcesResponse,
-    PlexApiTrackResponse,
     PlexMediaTypes,
-    PlexServerIdentity,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from .api_types import (
+        PlexApiConnection,
+        PlexApiPlaylistResponse,
+        PlexApiPlaylistTrackResponse,
+        PlexApiResourcesResponse,
+        PlexApiTrackResponse,
+        PlexServerIdentity,
+    )
 
 
 class PlexToken(Token):
@@ -130,7 +135,7 @@ class PlexApiSession(PlistsyncSession, TokenSession[PlexToken]):
             self.token.validated = True
         except requests.exceptions.RequestException as e:
             raise ValueError(
-                f"Plex token validation failed due to network error: {str(e)}"
+                f"Plex token validation failed due to network error: {e!s}"
             ) from e
 
     def request(

--- a/plistsync/services/plex/authenticate.py
+++ b/plistsync/services/plex/authenticate.py
@@ -120,7 +120,7 @@ def auth(
             if not success:
                 raise AuthenticationError("Failed to authenticate with Plex.")
     except AuthenticationError as e:
-        typer.echo(f"Authentication failed: {str(e)}")
+        typer.echo(f"Authentication failed: {e!s}")
         return typer.Exit(code=1)
 
     # Save the token

--- a/plistsync/services/plex/library.py
+++ b/plistsync/services/plex/library.py
@@ -1,20 +1,25 @@
-from collections.abc import Iterable, Sequence
+from __future__ import annotations
+
 from functools import cached_property
 from pathlib import Path
-from typing import overload
+from typing import TYPE_CHECKING, overload
 
 from requests import HTTPError
 
-from plistsync.core import Library, PathRewrite, TrackID
+from plistsync.core import Library
 from plistsync.core.collection import IDLookup, TrackStream
-from plistsync.core.ids import ISRC, FilePath
-from plistsync.core.playlist import PlaylistID
+from plistsync.core.ids import ISRC, FilePath, PlaylistID
 from plistsync.logger import log
-from plistsync.services.local.track import FileCache
 from plistsync.services.plex.playlist import PlexPlaylist, PlexPlaylistID
 
 from .api import PlexApi
 from .track import PlexTrack, PlexTrackID
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from plistsync.core import PathRewrite, TrackID
+    from plistsync.services.local.track import FileCache
 
 
 class PlexLibrary(

--- a/plistsync/services/plex/playlist.py
+++ b/plistsync/services/plex/playlist.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from plistsync.core.ids import PlaylistID
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
-    PlaylistID,
     PlaylistInfo,
 )
 from plistsync.logger import log
 
-from .api import PlexApi
-from .api_types import (
-    PlexApiPlaylistResponse,
-    PlexApiPlaylistTrackResponse,
-)
 from .track import PlexTrack
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .api import PlexApi
+    from .api_types import (
+        PlexApiPlaylistResponse,
+        PlexApiPlaylistTrackResponse,
+    )
     from .library import PlexLibrary
 
 

--- a/plistsync/services/plex/track.py
+++ b/plistsync/services/plex/track.py
@@ -2,17 +2,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import ClassVar, Self
+from typing import TYPE_CHECKING, ClassVar, Self
 
-from plistsync.core import PathRewrite, Track, TrackID, TrackInfo
+from plistsync.core import Track, TrackID, TrackInfo
 from plistsync.core.ids import FilePath, Scope
 from plistsync.logger import log
-from plistsync.services.plex.api_types import (
-    PlexApiPlaylistTrackResponse,
-    PlexApiTrackResponse,
-)
 
-from ..local.track import FileCache, LocalTrack
+from ..local.track import LocalTrack
+
+if TYPE_CHECKING:
+    from plistsync.core import PathRewrite
+    from plistsync.services.plex.api_types import (
+        PlexApiPlaylistTrackResponse,
+        PlexApiTrackResponse,
+    )
+
+    from ..local.track import FileCache
 
 
 @dataclass(frozen=True)

--- a/plistsync/services/registry.py
+++ b/plistsync/services/registry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import inspect
+from abc import ABC
+from functools import cache
+from typing import ClassVar, Self
+
+
+class Registry:
+    """Automatically register concrete subclasses by service.
+
+    Each abstract subclass of :class:`Registry` defines its own independent
+    registry. Concrete implementations are automatically registered when the
+    class is created.
+
+    The service name is derived from the module path::
+
+        plistsync.services.<service>.*
+
+    Subclasses may override this by providing an explicit ``service`` value.
+
+    Example:
+
+        .. code-block:: python
+
+            class PlaylistId(ABC, Registry):
+                ...
+
+            # plistsync.services.spotify.ids
+            class SpotifyPlaylistId(PlaylistId):
+                ...
+
+            # plistsync.services.apple.ids
+            class ApplePlaylistId(PlaylistId):
+                ...
+
+            PlaylistId.registry() == {
+                "spotify": [SpotifyPlaylistId],
+                "apple": [ApplePlaylistId],
+            }
+
+    Abstract subclasses become registry roots and are not registered
+    themselves. Only concrete subclasses are added to the registry.
+    """
+
+    _REGISTRY: ClassVar[dict[type, dict[str, list[type]]]] = {}
+    """Global registry for storing **all** registered classes."""
+
+    _registry: ClassVar[type[Registry] | None] = None
+    """Semi global registry key for this class and its subclasses.
+    Subclasses must define this but this can be overridden in subclasses to
+    register under a different key."""
+
+    def __init_subclass__(
+        cls,
+        *,
+        service: str | None = None,
+        **kwargs,
+    ):
+        super().__init_subclass__(**kwargs)
+
+        # Abstract bases become the registry key for their concrete subclasses.
+        if inspect.isabstract(cls) or ABC in cls.__bases__:
+            cls._registry = cls
+            return
+
+        if cls._registry is None:
+            raise ValueError(
+                f"Cannot register {cls.__name__!r}, it does not define a registry key."
+            )
+
+        service_name = service or cls.service()
+
+        registry_bucket = cls._REGISTRY.setdefault(cls._registry, {})
+        registry_bucket.setdefault(service_name, []).append(cls)
+
+    @classmethod
+    @cache
+    def service(cls) -> str:
+        """Return the service name for this class."""
+        module_str = cls.__module__
+        if not module_str.startswith("plistsync.services."):
+            raise ValueError(f"Cannot derive service name for {cls.__name__!r}")
+
+        return module_str.split(".")[2]
+
+    @classmethod
+    def registry(cls) -> dict[str, list[type[Self]]]:
+        """Return the registry for this class."""
+        if cls._registry is None:
+            raise ValueError(f"Cannot get registry for {cls.__name__!r}, not defined!")
+        return cls._REGISTRY.setdefault(cls._registry, {})

--- a/plistsync/services/spotify/__init__.py
+++ b/plistsync/services/spotify/__init__.py
@@ -13,10 +13,7 @@ from .track import SpotifyPlaylistTrack, SpotifyTrack, SpotifyTrackID
 
 
 class SpotifyService(Service):
-    library_cls = SpotifyLibrary
-    track_cls = SpotifyTrack
-    playlist_cls = SpotifyPlaylist
-    playlist_id_cls = SpotifyPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/spotify/api.py
+++ b/plistsync/services/spotify/api.py
@@ -5,7 +5,6 @@ from time import sleep
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 import requests
-from requests.structures import CaseInsensitiveDict
 
 from plistsync.logger import log
 from plistsync.utils import chunk_list
@@ -16,16 +15,15 @@ from plistsync.utils.auth.bearer_token import (
 )
 from plistsync.utils.session import PlistsyncSession
 
-from .api_types import (
-    PlaylistTracks,
-    PlaylistTracksBase,
-    SpotifyApiPlaylistTrack,
-)
-
 if TYPE_CHECKING:
+    from requests.structures import CaseInsensitiveDict
+
     from .api_types import (
+        PlaylistTracks,
+        PlaylistTracksBase,
         SpotifyApiPlaylistResponseFull,
         SpotifyApiPlaylistResponseSimplified,
+        SpotifyApiPlaylistTrack,
         SpotifyApiTrackResponse,
     )
 

--- a/plistsync/services/spotify/authenticate.py
+++ b/plistsync/services/spotify/authenticate.py
@@ -94,7 +94,7 @@ def auth(
         else:
             results = start_redirect_server(redirect_port, OAuthRedirectHandler, {})
     except AuthenticationError as e:
-        typer.echo(f"Authentication failed: {str(e)}")
+        typer.echo(f"Authentication failed: {e!s}")
         return typer.Exit(code=1)
 
     # Send request to get spotify token

--- a/plistsync/services/spotify/library.py
+++ b/plistsync/services/spotify/library.py
@@ -1,20 +1,24 @@
-from collections.abc import Iterable, Sequence
-from typing import overload
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, overload
 
 from requests import HTTPError
 
-from plistsync.core import TrackID
 from plistsync.core.collection import (
     IDLookup,
     Library,
 )
-from plistsync.core.ids import ISRC
-from plistsync.core.playlist import PlaylistID
+from plistsync.core.ids import ISRC, PlaylistID
 from plistsync.logger import log
 
 from .api import SpotifyApi
 from .playlist import SpotifyPlaylist, SpotifyPlaylistID
 from .track import SpotifyTrack, SpotifyTrackID
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from plistsync.core import TrackID
 
 
 class SpotifyLibrary(

--- a/plistsync/services/spotify/playlist.py
+++ b/plistsync/services/spotify/playlist.py
@@ -1,27 +1,29 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from plistsync.core.ids import PlaylistID
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
-    PlaylistID,
     PlaylistInfo,
 )
 
-from .api_types import (
-    PlaylistTracksBase,
-    SpotifyApiPlaylistResponseBase,
-    SpotifyApiPlaylistResponseFull,
-    SpotifyApiPlaylistResponseSimplified,
-    SpotifyApiPlaylistTrack,
-)
-from .track import SpotifyPlaylistTrack, SpotifyTrack
+from .track import SpotifyPlaylistTrack
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .api_types import (
+        PlaylistTracksBase,
+        SpotifyApiPlaylistResponseBase,
+        SpotifyApiPlaylistResponseFull,
+        SpotifyApiPlaylistResponseSimplified,
+        SpotifyApiPlaylistTrack,
+    )
     from .library import SpotifyLibrary
+    from .track import SpotifyTrack
 
 
 @dataclass(frozen=True)

--- a/plistsync/services/spotify/track.py
+++ b/plistsync/services/spotify/track.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from plistsync.core import Track, TrackID, TrackInfo
 from plistsync.core.ids import ISRC
-from plistsync.services.spotify.api_types import (
-    AddedBy,
-    SpotifyApiPlaylistTrack,
-    SpotifyApiTrackResponse,
-)
+
+if TYPE_CHECKING:
+    from plistsync.services.spotify.api_types import (
+        AddedBy,
+        SpotifyApiPlaylistTrack,
+        SpotifyApiTrackResponse,
+    )
 
 
 @dataclass(frozen=True)

--- a/plistsync/services/tidal/__init__.py
+++ b/plistsync/services/tidal/__init__.py
@@ -13,10 +13,7 @@ from .track import TidalPlaylistTrack, TidalTrack, TidalTrackID
 
 
 class TidalService(Service):
-    library_cls = TidalLibrary
-    track_cls = TidalTrack
-    playlist_cls = TidalPlaylist
-    playlist_id_cls = TidalPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/tidal/api.py
+++ b/plistsync/services/tidal/api.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import time
-from typing import Any, ClassVar, Literal, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 import requests
-from requests.structures import CaseInsensitiveDict
 
 from plistsync.logger import log
 from plistsync.utils import chunk_list
@@ -16,22 +15,28 @@ from plistsync.utils.auth.bearer_token import (
 from plistsync.utils.session import PlistsyncSession
 
 from .api_types import (
-    MultiRelationshipDataDocument,
-    MultiResourceDataDocument,
-    PlaylistDocument,
-    PlaylistIncludedResource,
-    PlaylistListDocument,
-    PlaylistResource,
-    PlaylistsItemsResourceIdentifier,
-    RelationshipResource,
     T_Included,
-    TrackDocument,
-    TrackIncludedResource,
-    TrackListDocument,
-    TrackResource,
-    UserDocument,
-    UserResource,
 )
+
+if TYPE_CHECKING:
+    from requests.structures import CaseInsensitiveDict
+
+    from .api_types import (
+        MultiRelationshipDataDocument,
+        MultiResourceDataDocument,
+        PlaylistDocument,
+        PlaylistIncludedResource,
+        PlaylistListDocument,
+        PlaylistResource,
+        PlaylistsItemsResourceIdentifier,
+        RelationshipResource,
+        TrackDocument,
+        TrackIncludedResource,
+        TrackListDocument,
+        TrackResource,
+        UserDocument,
+        UserResource,
+    )
 
 # It is more performant to have a lookup here instead of a list
 # for included resources (type,id) -> resource
@@ -475,7 +480,7 @@ class TidalPlaylistApi:
         if len(doc["data"]) != 1:
             raise ValueError(f"Playlist with id {id} not found")
 
-        return cast(PlaylistDocument, {**doc, "data": doc["data"][0]})
+        return cast("PlaylistDocument", {**doc, "data": doc["data"][0]})
 
     def get(
         self,

--- a/plistsync/services/tidal/authenticate.py
+++ b/plistsync/services/tidal/authenticate.py
@@ -98,7 +98,7 @@ def auth(
         else:
             results = start_redirect_server(redirect_port, OAuthRedirectHandler, {})
     except AuthenticationError as e:
-        typer.echo(f"Authentication failed: {str(e)}")
+        typer.echo(f"Authentication failed: {e!s}")
         return typer.Exit(code=1)
 
     # Send request to get tidal token

--- a/plistsync/services/tidal/library.py
+++ b/plistsync/services/tidal/library.py
@@ -1,20 +1,24 @@
-from collections.abc import Iterable, Sequence
-from typing import overload
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, overload
 
 from requests import HTTPError
 
-from plistsync.core import TrackID
 from plistsync.core.collection import (
     IDLookup,
     Library,
 )
-from plistsync.core.ids import ISRC
-from plistsync.core.playlist import PlaylistID
+from plistsync.core.ids import ISRC, PlaylistID
 from plistsync.logger import log
 
 from .api import TidalApi
 from .playlist import TidalPlaylist, TidalPlaylistID
 from .track import TidalTrack, TidalTrackID
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from plistsync.core import TrackID
 
 
 class TidalLibrary(
@@ -140,7 +144,7 @@ class TidalLibrary(
 
         Prioritizes tidal ID lookups over ISRC lookups.
         """
-        return list(self.find_many_by_ids([ids]))[0]
+        return next(iter(self.find_many_by_ids([ids])))
 
     def find_many_by_ids(
         self, track_ids_batch: Iterable[Iterable[TrackID]]

--- a/plistsync/services/tidal/playlist.py
+++ b/plistsync/services/tidal/playlist.py
@@ -1,24 +1,29 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from plistsync.core.ids import PlaylistID
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
-    PlaylistID,
     PlaylistInfo,
-    Snapshot,
 )
 from plistsync.logger import log
 
-from .api import LookupDict
-from .api_types import PlaylistResource
-from .track import TidalPlaylistTrack, TidalTrack
+from .track import TidalPlaylistTrack
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable, Sequence
+
+    from plistsync.core.playlist import (
+        Snapshot,
+    )
+
+    from .api import LookupDict
+    from .api_types import PlaylistResource
     from .library import TidalLibrary
+    from .track import TidalTrack
 
 
 @dataclass(frozen=True)
@@ -203,7 +208,7 @@ class TidalPlaylist(MultiRequestServicePlaylist[TidalPlaylistTrack]):
         # Deletion is done via itemId (unique in playlist)
         self.api.playlist.remove_items(
             playlist_id=str(self.id),
-            item_ids=[(t.id, cast(str, t.item_id)) for t in track],
+            item_ids=[(t.id, cast("str", t.item_id)) for t in track],
         )
 
     def _remote_update_metadata(

--- a/plistsync/services/tidal/track.py
+++ b/plistsync/services/tidal/track.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from plistsync.core import Track, TrackID, TrackInfo
 from plistsync.core.ids import ISRC
-from plistsync.services.tidal.api_types import (
-    PlaylistsItemsResourceIdentifierMeta,
-    TrackResource,
-)
 
-from .api import LookupDict
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from plistsync.services.tidal.api_types import (
+        PlaylistsItemsResourceIdentifierMeta,
+        TrackResource,
+    )
+
+    from .api import LookupDict
 
 
 @dataclass(frozen=True)

--- a/plistsync/services/traktor/__init__.py
+++ b/plistsync/services/traktor/__init__.py
@@ -13,10 +13,7 @@ from .track import NMLPlaylistTrack, NMLTrack
 
 
 class TraktorService(Service):
-    library_cls = NMLLibrary
-    playlist_cls = NMLPlaylist
-    track_cls = NMLTrack
-    playlist_id_cls = NMLPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/traktor/library.py
+++ b/plistsync/services/traktor/library.py
@@ -1,28 +1,31 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from datetime import date, datetime
 from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING, overload
-from uuid import UUID
 
 from lxml import etree
 
 from plistsync.config import Config
-from plistsync.core import TrackID
 from plistsync.core.collection import IDLookup, Library, TrackStream
-from plistsync.core.ids import FilePath
-from plistsync.core.playlist import PlaylistID
+from plistsync.core.ids import FilePath, PlaylistID
 from plistsync.logger import log
 
 from .path import NMLPath
 from .playlist import NMLPlaylist, NMLPlaylistID
-from .track import NMLPlaylistTrack, NMLTrack
+from .track import NMLTrack
 from .utility import sanitize_plist_name, xpath_string_escape
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from uuid import UUID
+
     from lxml.etree import _Element, _ElementTree
+
+    from plistsync.core import TrackID
+
+    from .track import NMLPlaylistTrack
 
 
 class NMLLibrary(

--- a/plistsync/services/traktor/path.py
+++ b/plistsync/services/traktor/path.py
@@ -1,8 +1,15 @@
-import re
-from pathlib import PurePath, PurePosixPath, PureWindowsPath
-from typing import Literal, Self
+from __future__ import annotations
 
-from lxml.etree import Element, SubElement, _Element
+import re
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Literal, Self
+
+from lxml.etree import Element, SubElement
+
+if TYPE_CHECKING:
+    from pathlib import PurePath
+
+    from lxml.etree import _Element
 
 
 class NMLPath:

--- a/plistsync/services/traktor/playlist.py
+++ b/plistsync/services/traktor/playlist.py
@@ -1,26 +1,22 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from lxml.etree import Element, SubElement, _Element
+from lxml.etree import Element, SubElement
 
-from plistsync.core import TrackID
 from plistsync.core.collection import IDLookup
-from plistsync.core.ids import FilePath
+from plistsync.core.ids import FilePath, PlaylistID
 from plistsync.core.playlist import (
-    PlaylistID,
     PlaylistInfo,
     ServicePlaylist,
-    Snapshot,
 )
 from plistsync.logger import log
 
 from .path import NMLPath
-from .track import NMLPlaylistTrack, NMLTrack
+from .track import NMLPlaylistTrack
 from .utility import (
     detach,
     sanitize_plist_name,
@@ -28,7 +24,17 @@ from .utility import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from lxml.etree import _Element
+
+    from plistsync.core import TrackID
+    from plistsync.core.playlist import (
+        Snapshot,
+    )
+
     from .library import NMLLibrary
+    from .track import NMLTrack
 
 
 @dataclass(frozen=True)

--- a/plistsync/services/traktor/track.py
+++ b/plistsync/services/traktor/track.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import re
-from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 from lxml.etree import Element, SubElement
 
-from plistsync.core import Track, TrackID, TrackInfo
+from plistsync.core import Track, TrackInfo
 from plistsync.core.ids import FilePath
 
 from .path import NMLPath
 
 if TYPE_CHECKING:
+    from pathlib import PurePath
+
     from lxml.etree import _Element
+
+    from plistsync.core import TrackID
 
     from .library import NMLLibrary
 
@@ -26,7 +29,7 @@ class NMLTrack(Track):
         MODIFIED_DATE="2024/5/27"
         MODIFIED_TIME="11734"
         AUDIO_ID="API...AAA=="
-        TITLE="It’s Not My Time"
+        TITLE="It's Not My Time"
         ARTIST="3 Doors Down"
     >
         <LOCATION

--- a/plistsync/services/traktor/utility.py
+++ b/plistsync/services/traktor/utility.py
@@ -1,4 +1,9 @@
-from lxml.etree import _Element
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
 
 
 def xpath_string_escape(input_str: str) -> str:

--- a/plistsync/utils/__init__.py
+++ b/plistsync/utils/__init__.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import dataclasses
 import json
 import os
 import pathlib
 import re
 import urllib.parse
-from collections.abc import Iterable
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class EnhancedJSONEncoder(json.JSONEncoder):

--- a/plistsync/utils/auth/bearer_token.py
+++ b/plistsync/utils/auth/bearer_token.py
@@ -4,11 +4,14 @@ This module provides functionality to manage Bearer tokens, including loading, s
 json.
 """
 
+from __future__ import annotations
+
 import json
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Generic,
@@ -17,9 +20,11 @@ from typing import (
 )
 
 import requests
-from requests.structures import CaseInsensitiveDict
 from requests_oauth2client import BearerToken as BearerTokenOauth2Client
 from requests_oauth2client.tokens import ExpiredAccessToken
+
+if TYPE_CHECKING:
+    from requests.structures import CaseInsensitiveDict
 
 
 class Token(ABC):
@@ -242,8 +247,8 @@ class TokenSession(Generic[T], requests.Session, ABC):
 
 
 __all__ = [
-    "Token",
-    "Oauth2Token",
-    "TokenSession",
     "InvalidTokenError",
+    "Oauth2Token",
+    "Token",
+    "TokenSession",
 ]

--- a/plistsync/utils/auth/redirect.py
+++ b/plistsync/utils/auth/redirect.py
@@ -93,7 +93,7 @@ class BaseRedirectHandler(http.server.BaseHTTPRequestHandler, ABC, Generic[T]):
             <div class="card">"""
             + f"""<div class="card">
             <h1>Authentication Error</h1>
-            <p><strong>{str(error)}</strong></p>
+            <p><strong>{error!s}</strong></p>
             <p>Something went wrong!</p>
             </div>
             </body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,13 +115,16 @@ extend-include = ["*.ipynb"]
 target-version = "py311"
 
 [tool.ruff.lint]
+future-annotations = true
 select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
     "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
+    "RUF", # ruff
     "UP",  # pyupgrade
+    "TC",  # flake8-type-checking
     "PTH", # Use pathlib instead of os.path
     "D",   # pydocstyle
     "W",   # pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,16 @@ typed = [
 [project.scripts]
 plistsync = "plistsync.__main__:cli"
 
+[project.entry-points."plistsync.services"]
+# This defines alll actionable services for plistsync.
+# Each service is a class that implements the Service interface.
+spotify = "plistsync.services.spotify:SpotifyService"
+tidal = "plistsync.services.tidal:TidalService"
+plex = "plistsync.services.plex:PlexService"
+local = "plistsync.services.local:LocalService"
+traktor = "plistsync.services.traktor:TraktorService"
+beets = "plistsync.services.beets:BeetsService"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/abc/collection.py
+++ b/tests/abc/collection.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
 import pytest
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TYPE_CHECKING
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 
-from plistsync.core import Library, Track, Collection
+from plistsync.core import Track
 from plistsync.core.collection import (
     IDLookup,
     InfoLookup,
@@ -13,6 +14,9 @@ from plistsync.core.matching import Matches
 from plistsync.core.playlist import (
     Playlist,
 )
+
+if TYPE_CHECKING:
+    from plistsync.core import Library, Collection
 
 
 class CollectionTestBase(ABC):

--- a/tests/abc/playlist.py
+++ b/tests/abc/playlist.py
@@ -1,18 +1,23 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import Any, ClassVar, ParamSpec, TypeVar
-from collections.abc import Callable
+from typing import Any, ClassVar, ParamSpec, TypeVar, TYPE_CHECKING
 from unittest.mock import ANY, Mock
 
 import pytest
 
 from plistsync.core import PlaylistID
 from plistsync.core.playlist import (
-    MultiRequestServicePlaylist,
-    Playlist,
-    ServicePlaylist,
     Snapshot,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from plistsync.core.playlist import (
+        MultiRequestServicePlaylist,
+        Playlist,
+        ServicePlaylist,
+    )
 
 
 P = ParamSpec("P")

--- a/tests/abc/tracks.py
+++ b/tests/abc/tracks.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import PurePath
 
-from plistsync.core.track import Track
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.core.track import Track
 
 
 class TestTrack(ABC):

--- a/tests/core/crdt/test_fugue_bench.py
+++ b/tests/core/crdt/test_fugue_bench.py
@@ -85,7 +85,7 @@ def test_merge_scale(benchmark, replicas: int, ops_per: int) -> None:
 
 
 def test_playlist_edit_session(benchmark) -> None:
-    """Build 500 tracks, delete 100, re-add 50, fork 2×, merge all."""
+    """Build 500 tracks, delete 100, re-add 50, fork 2x, merge all."""
 
     def run() -> Fugue[str]:
         fu: Fugue[str] = Fugue()

--- a/tests/core/crdt/test_lww.py
+++ b/tests/core/crdt/test_lww.py
@@ -1,0 +1,313 @@
+"""Tests for the op-based LWW Register CRDT."""
+
+from __future__ import annotations
+
+import pytest
+
+from plistsync.core.crdt.graph import NodeID
+from plistsync.core.crdt.lww import LWWRegister, RegisterOp
+
+
+def _new_register(replica_id: int = 0) -> LWWRegister:
+    return LWWRegister(replica_id)
+
+
+def _op(field: str, value: object, replica: int = 0, counter: int = 0) -> RegisterOp:
+    return RegisterOp(field, value, NodeID(replica, counter))
+
+
+def _op_count(reg: LWWRegister) -> int:
+    """Total number of ops in *reg*, via the public history API."""
+    return sum(len(reg.history(field)) for field in reg)
+
+
+class TestMapping:
+    """Read-only Mapping protocol over current field values."""
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("name", "Playlist"), ("description", "Desc"), ("empty", ""), ("none", None)],
+    )
+    def test_assign_and_get(self, field, value):
+        reg = _new_register()
+        reg.assign(field, value)
+        assert reg[field] == value
+
+    def test_getitem_missing_raises(self):
+        with pytest.raises(KeyError):
+            _new_register()["missing"]
+
+    def test_get_with_default(self):
+        reg = _new_register()
+        assert reg.get("missing") is None
+        assert reg.get("missing", "fallback") == "fallback"
+        reg.assign("name", "A")
+        assert reg.get("name", "fallback") == "A"
+
+    def test_len_contains_iteration(self):
+        reg = _new_register()
+        assert len(reg) == 0 and "name" not in reg
+
+        reg.assign("name", "A")
+        reg.assign("desc", "B")
+
+        assert len(reg) == 2 and "name" in reg
+        assert set(reg) == {"name", "desc"}
+
+    def test_views_and_equality(self):
+        reg = _new_register()
+        reg.assign("name", "A")
+        reg.assign("desc", "B")
+
+        assert set(reg.items()) == {("name", "A"), ("desc", "B")}
+        assert set(reg.keys()) == {"name", "desc"}
+        assert set(reg.values()) == {"A", "B"}
+
+        other = _new_register()
+        other.assign("name", "A")
+        assert other == {"name": "A"}
+        assert other != {"name": "B"}
+
+    def test_setitem_assigns(self):
+        reg = _new_register()
+        reg["name"] = "A"
+
+        assert reg["name"] == "A"
+        assert [op.key for op in reg.history("name")] == ["name"]
+
+    def test_fields_cannot_be_deleted(self):
+        reg = _new_register()
+        reg.assign("name", "A")
+        with pytest.raises(TypeError):
+            del reg["name"]  # type: ignore[attr-defined]
+
+
+class TestOpsAndClock:
+    """Op creation, history, and the Lamport clock."""
+
+    def test_assign_creates_valid_op(self):
+        op = _new_register(5).assign("name", "A")
+        assert (op.key, op.value, op.version) == ("name", "A", NodeID(5, 0))
+
+    def test_first_op_uses_counter_zero(self):
+        reg = _new_register(3)
+        assert reg.assign("name", "A").version == NodeID(3, 0)
+        assert reg.version() == NodeID(3, 1)
+
+    def test_version_reflects_clock(self):
+        reg = _new_register(2)
+        assert reg.version() == NodeID(2, 0)
+
+        reg.assign("name", "A")
+        reg.assign("name", "B")
+        assert reg.version() == NodeID(2, 2)
+
+        reg.apply(_op("name", "C", replica=7, counter=41))
+        assert reg.version().counter == 42
+
+    def test_clock_advances_past_remote_ops(self):
+        reg = _new_register()
+        reg.apply(_op("name", "remote", replica=1, counter=41))
+
+        # Local op must be timestamped strictly after the observed remote op.
+        assert reg.assign("name", "local").version.counter > 41
+        assert reg["name"] == "local"
+
+    def test_history(self):
+        reg = _new_register()
+        for value in ("A", "B"):
+            reg.assign("name", value)
+
+        assert [op.value for op in reg.history("name")] == ["A", "B"]
+
+    def test_last_op_by(self):
+        a, b = _new_register(0), _new_register(1)
+        a.assign("name", "A1")
+        a.assign("name", "A2")
+        b.assign("name", "B1")
+        a.merge(b)
+
+        assert a.last_op_by("name", 0).value == "A2"  # type: ignore[union-attr]
+        assert a.last_op_by("name", 1).value == "B1"  # type: ignore[union-attr]
+
+    def test_last_op_by_unknown_field_or_replica(self):
+        reg = _new_register(0)
+        reg.assign("name", "A")
+
+        assert reg.last_op_by("other-field", 0) is None
+        assert reg.last_op_by("name", 7) is None
+
+    def test_register_op_is_frozen(self):
+        v = NodeID(0, 0)
+        assert RegisterOp("a", 1, v) == RegisterOp("a", 1, v)
+        assert RegisterOp("a", 1, v) != RegisterOp("a", 2, v)
+        with pytest.raises(Exception):
+            RegisterOp("a", 1, v).value = 2  # type: ignore[misc]
+
+
+class TestResolution:
+    """Last-writer-wins semantics under Lamport ordering."""
+
+    @pytest.mark.parametrize(
+        "ops, expected",
+        [
+            ([_op("name", "A", counter=0)], "A"),
+            ([_op("name", "A", counter=0), _op("name", "B", counter=1)], "B"),
+            ([_op("name", "A", 0, 1), _op("name", "B", 1, 1)], "B"),
+            # Fresher low-replica write beats stale high-replica write
+            # (counter first, replica id only as tie-breaker).
+            ([_op("name", "fresh", 0, 100), _op("name", "stale", 1, 0)], "fresh"),
+            ([_op("name", "stale", 1, 0), _op("name", "fresh", 0, 100)], "fresh"),
+            # Equal counters: replica id breaks the tie.
+            ([_op("name", "A", 0, 5), _op("name", "B", 1, 5)], "B"),
+        ],
+    )
+    def test_lww_ordering(self, ops, expected):
+        reg = _new_register()
+        for op in ops:
+            reg.apply(op)
+        assert reg["name"] == expected
+
+    def test_apply_is_idempotent(self):
+        reg = _new_register()
+        op = _op("name", "A")
+
+        assert reg.apply(op)
+        assert not reg.apply(op)
+        assert reg["name"] == "A"
+
+    def test_apply_order_independent(self):
+        ops = [_op("name", v, counter=i) for i, v in enumerate("ABC")]
+        a, b = _new_register(), _new_register()
+
+        for op in ops:
+            a.apply(op)
+        for op in reversed(ops):
+            b.apply(op)
+
+        assert a["name"] == b["name"] == "C"
+
+    def test_fields_are_independent(self):
+        reg = _new_register()
+        reg.apply(_op("name", "A"))
+        reg.apply(_op("desc", "B", counter=1))
+
+        assert reg["name"] == "A"
+        assert reg["desc"] == "B"
+
+
+class TestMerge:
+    def test_merge(self):
+        a, b = _new_register(0), _new_register(1)
+        a.assign("name", "A")
+        b.assign("desc", "B")
+
+        a.merge(b)
+
+        assert a["name"] == "A"
+        assert a["desc"] == "B"
+
+    def test_conflict_converges(self):
+        a, b = _new_register(0), _new_register(1)
+        a.assign("name", "A")
+        b.assign("name", "B")
+
+        a.merge(b)
+        b.merge(a)
+
+        assert a["name"] == b["name"] == "B"
+        assert len(a.history("name")) == 2
+
+    def test_concurrent_writes_converge(self):
+        # Replica 0 is causally later (higher counter) and must win everywhere.
+        a, b = _new_register(0), _new_register(1)
+        for _ in range(5):
+            a.assign("name", "from-a")
+        b.assign("name", "from-b")
+
+        a.merge(b)
+        b.merge(a)
+
+        assert a["name"] == b["name"] == "from-a"
+
+    def test_duplicate_ops_ignored(self):
+        a, b = _new_register(), _new_register()
+        op = _op("name", "A")
+        a.apply(op)
+        b.apply(op)
+
+        a.merge(b)
+        a.merge(b)
+
+        assert len(a.history("name")) == 1
+
+    def test_associative_and_commutative(self):
+        a, b, c = _new_register(0), _new_register(1), _new_register(2)
+        a.assign("name", "A")
+        b.assign("name", "B")
+        b.assign("desc", "b-desc")
+        c.assign("name", "C")
+
+        def merged(sources: tuple[LWWRegister, ...]) -> LWWRegister:
+            r = _new_register(9)
+            for src in sources:
+                r.merge(src)
+            return r
+
+        r1, r2 = merged((a, b, c)), merged((c, a, b))
+        assert r1["name"] == r2["name"]
+        assert r1["desc"] == r2["desc"] == "b-desc"
+        assert _op_count(r1) == _op_count(r2)
+
+
+class TestForkAndTimeTravel:
+    def test_fork_creates_independent_replica(self):
+        a = _new_register(0)
+        a.assign("name", "A")
+
+        b = a.fork(replica_id=1)
+
+        assert b.replica_id == 1
+        assert b["name"] == "A"
+
+        b.assign("name", "B")
+        assert a["name"] == "A"
+        assert b["name"] == "B"
+        assert b.history("name")[-1].version.replica_id == 1
+
+    def test_time_travel_excludes_later_ops(self):
+        reg = _new_register(0)
+        reg.assign("name", "first")
+        cutoff = reg.version()  # causally after "first"
+        reg.assign("name", "second")
+
+        past = reg.time_travel(cutoff)
+
+        assert past["name"] == "first"
+        assert reg["name"] == "second"
+        assert len(reg.history("name")) == 2
+
+    def test_time_travel_respects_lamport_causality(self):
+        # Ops with a counter below the cutoff are included; later concurrent
+        # ops are excluded.
+        reg = _new_register(0)
+        reg.apply(_op("name", "early", replica=1, counter=1))
+        reg.apply(_op("name", "late", replica=1, counter=50))
+
+        assert reg.time_travel(NodeID(0, 10))["name"] == "early"
+
+
+class TestMisc:
+    @pytest.mark.parametrize("value", [None, "", "value", 123])
+    def test_values_can_be_any_type(self, value):
+        reg = _new_register()
+        reg.assign("field", value)
+        assert reg["field"] == value
+
+    def test_large_update_sequence(self):
+        reg = _new_register()
+        for i in range(1000):
+            reg.assign("name", i)
+
+        assert reg["name"] == 999
+        assert len(reg.history("name")) == 1000

--- a/tests/core/crdt/test_serialize.py
+++ b/tests/core/crdt/test_serialize.py
@@ -132,7 +132,7 @@ class TestDump:
 
     def test_insert_op_shape(self, s: FugueSerializer[str, str]) -> None:
         fu = _fugue("x")
-        op = cast(OpStateInsert, s.dump(fu)["ops"][0])
+        op = cast("OpStateInsert", s.dump(fu)["ops"][0])
         for k in ("node_id", "parent_id", "side", "right_of_id", "value_ref"):
             assert k in op
         assert op["side"] in (0, 1)
@@ -172,8 +172,8 @@ class TestDump:
         for o, r in zip(state["ops"], restate["ops"]):
             if "right_of_id" in o:
                 assert (
-                    cast(OpStateInsert, o)["right_of_id"]
-                    == cast(OpStateInsert, r)["right_of_id"]
+                    cast("OpStateInsert", o)["right_of_id"]
+                    == cast("OpStateInsert", r)["right_of_id"]
                 )
 
 

--- a/tests/core/mock_collections.py
+++ b/tests/core/mock_collections.py
@@ -1,15 +1,19 @@
-from collections.abc import Iterable, Iterator
+from __future__ import annotations
 
-from plistsync.core import TrackID
 from plistsync.core.collection import (
     Collection,
     IDLookup,
     InfoLookup,
     TrackStream,
 )
-from plistsync.core.track import TrackInfo
 
-from .mock_track import MockTrack
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .mock_track import MockTrack
+    from plistsync.core.track import TrackInfo
+    from plistsync.core import TrackID
+    from collections.abc import Iterable, Iterator
 
 
 class MockIDLookupCollection(Collection, IDLookup):

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
 import random
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from unittest.mock import Mock
 from plistsync.core.playlist import (
     MultiRequestServicePlaylist,
     OfflinePlaylist,
     ServicePlaylist,
-    Snapshot,
 )
 from plistsync.core.track import OfflineTrack
+
+if TYPE_CHECKING:
+    from plistsync.core.playlist import (
+        Snapshot,
+    )
 
 
 class MockServicePlaylist(

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -11,8 +11,7 @@ from plistsync.core.track import OfflineTrack
 
 
 class MockServicePlaylist(
-    OfflinePlaylist,
-    ServicePlaylist[OfflineTrack],
+    OfflinePlaylist, ServicePlaylist[OfflineTrack], service="test"
 ):
     """Mock PlaylistCollection implementation for testing."""
 
@@ -31,8 +30,7 @@ class MockServicePlaylist(
 
 
 class MockMultiRequestServicePlaylist(
-    OfflinePlaylist,
-    MultiRequestServicePlaylist[OfflineTrack],
+    OfflinePlaylist, MultiRequestServicePlaylist[OfflineTrack], service="test"
 ):
     """Mock IncrementalPlaylistCollection implementation for testing."""
 

--- a/tests/core/mock_track.py
+++ b/tests/core/mock_track.py
@@ -1,5 +1,9 @@
-from plistsync.core import TrackID
+from __future__ import annotations
 from plistsync.core.track import Track, TrackInfo
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.core import TrackID
 
 
 class MockTrack(Track, service="test"):

--- a/tests/core/mock_track.py
+++ b/tests/core/mock_track.py
@@ -2,7 +2,7 @@ from plistsync.core import TrackID
 from plistsync.core.track import Track, TrackInfo
 
 
-class MockTrack(Track):
+class MockTrack(Track, service="test"):
     """Mock Track implementation for testing."""
 
     def __init__(

--- a/tests/core/sync/test_playlist.py
+++ b/tests/core/sync/test_playlist.py
@@ -1,0 +1,491 @@
+"""Tests for the SyncedPlaylist cross-service synchronisation logic."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from plistsync.core.ids import ISRC, PlaylistID
+from plistsync.core.crdt.lww import LWWRegister
+from plistsync.core.matching import Matches
+from plistsync.core.playlist import PlaylistInfo
+from plistsync.core.sync.playlist import SyncedPlaylist, SyncedPlaylistID
+from plistsync.core.track import OfflineTrack
+from plistsync.services.spotify import SpotifyPlaylistID
+from plistsync.services.tidal import TidalPlaylistID
+
+from ..mock_playlist import MockServicePlaylist
+from ..mock_track import MockTrack
+
+SPOTIFY_ID = SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M")
+TIDAL_ID = TidalPlaylistID.parse("tidal:playlist:1293")
+
+
+def make_track(title: str, isrc: str) -> MockTrack:
+    """Create a mock track with a unique title and ISRC.
+
+    Titles/artists must be distinct enough to not fuzzy-match each other
+    (Collection.match cutoff is 0.6), otherwise tests become non-deterministic.
+    """
+    return MockTrack(title=title, artists=[f"{title} Artist"], ids={ISRC(isrc)})
+
+
+def make_playlist(
+    tracks: list[MockTrack] | None = None,
+    id: PlaylistID = SPOTIFY_ID,
+    name: str = "Mock",
+) -> MockServicePlaylist:
+    """Create a mock service playlist with a stubbed-out library."""
+    playlist = MockServicePlaylist(
+        info=PlaylistInfo(name=name, description=None),
+        id=id,
+        tracks=tracks or [],
+    )
+    playlist.library = Mock()
+    # By default, the library knows nothing (all matching happens in-playlist).
+    playlist.library.match = Mock(
+        side_effect=lambda track: Matches(truth=track, found=[])
+    )
+    playlist.library.get_playlist_or_raise = Mock(side_effect=lambda id: playlist)
+    return playlist
+
+
+@pytest.fixture
+def track_a() -> MockTrack:
+    return make_track("Bohemian Rhapsody", "AAAA1111111A")
+
+
+@pytest.fixture
+def track_b() -> MockTrack:
+    return make_track("Lithium", "BBBB2222222B")
+
+
+@pytest.fixture
+def track_c() -> MockTrack:
+    return make_track("Toxicity", "CCCC3333333C")
+
+
+def isrcs(tracks) -> set[str]:
+    """Return the serials of all ISRCs of the given tracks."""
+    return {tid.serial for t in tracks for tid in t.ids}
+
+
+class TestSyncedPlaylistID:
+    def test_new_generates_unique_ids(self):
+        assert SyncedPlaylistID.new() != SyncedPlaylistID.new()
+
+    def test_parse_roundtrip(self):
+        pid = SyncedPlaylistID.new()
+        parsed = SyncedPlaylistID.parse(str(pid))
+        assert parsed == pid
+        assert parsed.serial == pid.serial
+
+    @pytest.mark.parametrize("value", ["not-a-uuid", "123", ""])
+    def test_parse_invalid_raises(self, value: str):
+        with pytest.raises(ValueError):
+            SyncedPlaylistID.parse(value)
+
+
+class TestSyncedPlaylistProtocol:
+    """The Playlist-protocol surface of SyncedPlaylist."""
+
+    def test_init_empty(self):
+        playlist = SyncedPlaylist("Name", description="desc")
+        assert playlist.info == {"name": "Name", "description": "desc"}
+        assert playlist.tracks == []
+        assert isinstance(playlist.id, SyncedPlaylistID)
+
+    def test_init_with_tracks(self, track_a, track_b):
+        playlist = SyncedPlaylist(
+            "Name", tracks=[OfflineTrack.from_track(track_a), track_b]
+        )
+        assert playlist.tracks == [track_a, track_b]
+
+    def test_info_setter(self):
+        playlist = SyncedPlaylist("Old")
+        playlist.info = PlaylistInfo(name="New", description=None)
+        assert playlist.name == "New"
+
+    def test_id(self):
+        assert isinstance(SyncedPlaylist("x").id, PlaylistID)
+
+    def test_tracks_setter_not_supported(self):
+        playlist = SyncedPlaylist("x")
+        with pytest.raises(NotImplementedError, match="sync"):
+            playlist.tracks = []
+
+
+class TestRegister:
+    def test_register_empty_playlist(self):
+        playlist = SyncedPlaylist("x")
+        service = make_playlist()
+
+        playlist.register(service)
+
+        assert playlist._linked_playlists == {1: service}
+        assert playlist.tracks == []
+
+    def test_register_merges_service_tracks(self, track_a, track_b):
+        playlist = SyncedPlaylist("x")
+        service = make_playlist([track_a, track_b])
+
+        playlist.register(service)
+
+        assert isrcs(playlist.tracks) == isrcs([track_a, track_b])
+
+    def test_register_preserves_internal_tracks(self, track_a, track_b):
+        playlist = SyncedPlaylist("x", tracks=[OfflineTrack.from_track(track_a)])
+        service = make_playlist([track_b])
+
+        playlist.register(service)
+
+        assert isrcs(playlist.tracks) == isrcs([track_a, track_b])
+
+    def test_register_pushes_internal_tracks(self, track_a, track_b):
+        """Tracks already in the internal collection appear in the new playlist."""
+        playlist = SyncedPlaylist("x", tracks=[OfflineTrack.from_track(track_a)])
+        service = make_playlist([track_b])
+        # The service's library can resolve track_a (it exists in its catalog).
+        service.library.match = Mock(
+            return_value=Matches(
+                truth=track_a, found=[track_a], found_similarities=[1.0]
+            )
+        )
+
+        playlist.register(service)
+
+        assert isrcs(service.tracks) == isrcs([track_b, track_a])
+
+    def test_register_assigns_incrementing_replica_ids(self):
+        playlist = SyncedPlaylist("x")
+        first, second = make_playlist(), make_playlist(id=TIDAL_ID)
+
+        playlist.register(first)
+        playlist.register(second)
+
+        assert playlist._linked_playlists == {1: first, 2: second}
+
+
+class TestRefresh:
+    def test_refresh_replaces_linked_playlists(self):
+        playlist = SyncedPlaylist("x")
+        service = make_playlist()
+        refreshed = make_playlist()
+        playlist.register(service)
+
+        service.library.get_playlist_or_raise = Mock(return_value=refreshed)
+        playlist.refresh()
+
+        service.library.get_playlist_or_raise.assert_called_once_with(id=service.id)
+        assert playlist._linked_playlists[1] is refreshed
+
+
+class TestMerge:
+    def test_merge_added_track(self, track_a, track_b):
+        playlist = SyncedPlaylist("x")
+        service = make_playlist([track_a])
+        playlist.register(service)
+
+        # External change: track_b added on the service
+        service.tracks = [track_a, track_b]
+        playlist.merge()
+
+        assert isrcs(playlist.tracks) == isrcs([track_a, track_b])
+
+    def test_merge_removed_track(self, track_a, track_b):
+        playlist = SyncedPlaylist("x")
+        service = make_playlist([track_a, track_b])
+        playlist.register(service)
+
+        # External change: track_a removed on the service
+        service.tracks = [track_b]
+        playlist.merge()
+
+        assert isrcs(playlist.tracks) == isrcs([track_b])
+
+    def test_merge_reordered_tracks(self, track_a, track_b):
+        playlist = SyncedPlaylist("x")
+        service = make_playlist([track_a, track_b])
+        playlist.register(service)
+
+        # External change: order flipped on the service
+        service.tracks = [track_b, track_a]
+        playlist.merge()
+
+        assert isrcs(playlist.tracks) == isrcs([track_b, track_a])
+        assert playlist.tracks[0].ids == track_b.ids
+
+    def test_merge_tracks_from_other_playlist_untouched(
+        self, track_a, track_b, track_c
+    ):
+        """A track missing from one service must not be deleted by its merge."""
+        playlist = SyncedPlaylist("x")
+        first = make_playlist([track_a, track_b])
+        second = make_playlist(id=TIDAL_ID)
+        playlist.register(first)
+        playlist.register(second)
+
+        # track_a + track_b are in the internal collection, but `second` is empty.
+        # track_c gets added to `second` externally.
+        second.tracks = [track_c]
+        playlist.merge()
+
+        # track_a/track_b (only in `first`) survive; track_c is merged in.
+        assert isrcs(playlist.tracks) == isrcs([track_a, track_b, track_c])
+
+
+class TestMergeInfo:
+    """Merging of playlist metadata (name/description) from linked playlists."""
+
+    def test_service_name_is_merged(self):
+        playlist = SyncedPlaylist("internal")
+        service = make_playlist(name="service")
+        playlist.register(service)
+
+        playlist.merge()
+
+        assert "name" in playlist.info
+        assert playlist.info["name"] == "service"
+
+    def test_unchanged_service_creates_no_ops(self):
+        playlist = SyncedPlaylist("internal")
+        service = make_playlist(name="service")
+        playlist.register(service)
+
+        playlist.merge()
+        ops_before = len(playlist._info.history("name"))
+        playlist.merge()
+
+        assert len(playlist._info.history("name")) == ops_before
+
+    def test_local_edit_not_clobbered_by_unchanged_service(self):
+        playlist = SyncedPlaylist("internal")
+        service = make_playlist(name="service")
+        playlist.register(service)
+        playlist.merge()
+
+        playlist.name = "local-edit"
+        playlist.merge()
+
+        assert "name" in playlist.info
+        assert playlist.info["name"] == "local-edit"
+
+    def test_service_rename_is_merged(self):
+        playlist = SyncedPlaylist("internal")
+        service = make_playlist(name="service")
+        playlist.register(service)
+        playlist.merge()
+
+        service.info = PlaylistInfo(name="renamed")
+        playlist.merge()
+
+        assert "name" in playlist.info
+        assert playlist.info["name"] == "renamed"
+
+    def test_conflicting_names_resolve_deterministically(self):
+        playlist = SyncedPlaylist("internal")
+        first = make_playlist(name="one")
+        second = make_playlist(name="two", id=TIDAL_ID)
+        playlist.register(first)
+        playlist.register(second)
+
+        playlist.merge()
+
+        # Replica 2 merged after replica 1, so its op has the higher counter.
+        assert "name" in playlist.info
+        assert playlist.info["name"] == "two"
+
+    def test_merge_is_order_independent(self):
+        """Replaying the produced ops in any order yields the same winner."""
+        playlist = SyncedPlaylist("internal")
+        first = make_playlist(name="one")
+        second = make_playlist(name="two", id=TIDAL_ID)
+        playlist._linked_playlists[1] = first
+        playlist._linked_playlists[2] = second
+        playlist.merge()
+
+        other = LWWRegister()
+        for op in reversed(playlist._info.history("name")):
+            other.apply(op)
+
+        assert "name" in playlist.info
+        assert other["name"] == playlist.info["name"]
+
+    def test_description_is_merged(self):
+        playlist = SyncedPlaylist("internal")
+        service = make_playlist(name="service")
+        service.info = PlaylistInfo(name="service", description="service desc")
+        playlist.register(service)
+
+        playlist.merge()
+
+        assert "description" in playlist.info
+        assert playlist.info["description"] == "service desc"
+
+    def test_missing_description_is_untouched(self):
+        """Fields absent from the service's info are not treated as deletions."""
+        playlist = SyncedPlaylist("internal", description="internal desc")
+        service = make_playlist(name="service")
+        service.info = PlaylistInfo(name="service")  # no description key
+        playlist.register(service)
+
+        playlist.merge()
+
+        assert "description" in playlist.info
+        assert playlist.info["description"] == "internal desc"
+
+    def test_none_description_clears_internal(self):
+        """An explicit None description overwrites/clears the internal value."""
+        playlist = SyncedPlaylist("internal", description="internal desc")
+        service = make_playlist(name="service")
+        service.info = PlaylistInfo(name="service", description=None)
+        playlist.register(service)
+
+        playlist.merge()
+
+        assert "description" in playlist.info
+        assert playlist.info["description"] is None
+
+
+class TestEnrich:
+    def test_enrich_adds_playlist_association_and_ids(self, track_a):
+        """A track present on the service gets linked and enriched."""
+        playlist = SyncedPlaylist("x", tracks=[OfflineTrack.from_track(track_a)])
+        service = make_playlist([track_a])
+        # Only register the playlist in the internal mapping, without
+        # going through register() (which already enriches).
+        playlist._linked_playlists[1] = service
+
+        service_track = MockTrack(
+            title=track_a.title,
+            artists=track_a.artists,
+            ids={ISRC("ZZZZ9999999Z")},
+        )
+        service.match = Mock(
+            return_value=Matches(
+                truth=track_a, found=[service_track], found_similarities=[1.0]
+            )
+        )
+
+        playlist.enrich()
+
+        (link,) = playlist._fugue
+        assert service.id in link.playlists
+        # The internal track picked up the id of its service match.
+        assert ISRC("ZZZZ9999999Z") in link.track.ids
+
+    def test_enrich_falls_back_to_library(self, track_a):
+        """If the playlist itself has no match, the library is consulted."""
+        playlist = SyncedPlaylist("x", tracks=[OfflineTrack.from_track(track_a)])
+        service = make_playlist()
+        playlist._linked_playlists[1] = service
+
+        service.library.match = Mock(
+            return_value=Matches(
+                truth=track_a, found=[track_a], found_similarities=[1.0]
+            )
+        )
+
+        playlist.enrich()
+
+        service.library.match.assert_called_once()
+        (link,) = playlist._fugue
+        assert service.id in link.playlists
+
+    def test_enrich_without_match_keeps_track_unlinked(self, track_a):
+        playlist = SyncedPlaylist("x", tracks=[OfflineTrack.from_track(track_a)])
+        service = make_playlist()
+        playlist._linked_playlists[1] = service
+
+        playlist.enrich()
+
+        (link,) = playlist._fugue
+        assert link.playlists == set()
+
+
+class TestPush:
+    def test_push_aligns_service_playlist(self, track_a, track_b):
+        playlist = SyncedPlaylist(
+            "x",
+            tracks=[OfflineTrack.from_track(track_a), OfflineTrack.from_track(track_b)],
+        )
+        service = make_playlist([track_a, track_b])
+        playlist._linked_playlists[1] = service
+        # Link the internal tracks to the service playlist.
+        for link in playlist._fugue:
+            link.playlists.add(service.id)
+
+        playlist.push()
+
+        assert isrcs(service.tracks) == isrcs([track_a, track_b])
+
+    def test_push_skips_unlinked_tracks(self, track_a, track_b):
+        """Tracks not associated with the playlist are not pushed."""
+        playlist = SyncedPlaylist(
+            "x",
+            tracks=[OfflineTrack.from_track(track_a), OfflineTrack.from_track(track_b)],
+        )
+        service = make_playlist([track_a])
+        playlist._linked_playlists[1] = service
+        # Only the first track is linked.
+        link = next(iter(playlist._fugue))
+        link.playlists.add(service.id)
+
+        playlist.push()
+
+        assert isrcs(service.tracks) == isrcs([track_a])
+
+    def test_push_removes_association_when_track_not_found(self, track_a):
+        """Unresolvable tracks are dropped from the playlist association."""
+        playlist = SyncedPlaylist("x", tracks=[OfflineTrack.from_track(track_a)])
+        service = make_playlist()
+        playlist._linked_playlists[1] = service
+        link = next(iter(playlist._fugue))
+        link.playlists.add(service.id)
+
+        # Neither the playlist nor the library can resolve the track.
+        service.match = Mock(return_value=Matches(truth=track_a, found=[]))
+
+        playlist.push()
+
+        assert service.id not in link.playlists
+        assert service.tracks == []
+
+
+class TestSync:
+    def test_sync_calls_phases_in_order(self):
+        playlist = SyncedPlaylist("x")
+        with (
+            patch.object(playlist, "refresh") as refresh,
+            patch.object(playlist, "merge") as merge,
+            patch.object(playlist, "enrich") as enrich,
+            patch.object(playlist, "push") as push,
+        ):
+            playlist.sync()
+
+        refresh.assert_called_once_with()
+        merge.assert_called_once_with()
+        enrich.assert_called_once_with()
+        push.assert_called_once_with()
+
+    def test_sync_end_to_end(self, track_a, track_b, track_c):
+        """Two service playlists converge to the same tracks after sync."""
+        playlist = SyncedPlaylist("x")
+        first = make_playlist([track_a, track_b])
+        second = make_playlist([track_c], id=TIDAL_ID)
+        # Both libraries can resolve every track (full catalog availability).
+        for service in (first, second):
+            service.library.match = Mock(
+                side_effect=lambda track: Matches(
+                    truth=track, found=[track], found_similarities=[1.0]
+                )
+            )
+        playlist.register(first)
+        playlist.register(second)
+
+        # External change: track_b removed from `first`
+        first.tracks = [track_a]
+        playlist.sync()
+
+        assert isrcs(playlist.tracks) == isrcs([track_a, track_c])
+        assert isrcs(first.tracks) == isrcs([track_a, track_c])
+        assert isrcs(second.tracks) == isrcs([track_a, track_c])

--- a/tests/core/sync/test_playlist.py
+++ b/tests/core/sync/test_playlist.py
@@ -173,7 +173,7 @@ class TestRefresh:
         playlist.register(service)
 
         service.library.get_playlist_or_raise = Mock(return_value=refreshed)
-        playlist.refresh()
+        playlist.fetch()
 
         service.library.get_playlist_or_raise.assert_called_once_with(id=service.id)
         assert playlist._linked_playlists[1] is refreshed
@@ -455,14 +455,14 @@ class TestSync:
     def test_sync_calls_phases_in_order(self):
         playlist = SyncedPlaylist("x")
         with (
-            patch.object(playlist, "refresh") as refresh,
+            patch.object(playlist, "fetch") as fetch,
             patch.object(playlist, "merge") as merge,
             patch.object(playlist, "enrich") as enrich,
             patch.object(playlist, "push") as push,
         ):
             playlist.sync()
 
-        refresh.assert_called_once_with()
+        fetch.assert_called_once_with()
         merge.assert_called_once_with()
         enrich.assert_called_once_with()
         push.assert_called_once_with()

--- a/tests/core/test_diff.py
+++ b/tests/core/test_diff.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from plistsync.core.diff import (
@@ -7,7 +8,15 @@ from plistsync.core.diff import (
     Operations,
     batch_consecutive,
     list_diff,
+    list_diff_eq,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.core.diff import (
+        Op,
+    )
+    from collections.abc import Callable
 
 
 class TestPlaylistDiff:
@@ -79,9 +88,9 @@ class TestPlaylistDiff:
                 [MoveOp(old_idx=1, new_idx=0, item="B")],
                 id="swap_two",
             ),
-       
+
         ],
-   
+
     )  # fmt: skip
     def test_playlist_diff(self, old, new, expected):
         """Comprehensive test suite for playlist_diff."""
@@ -162,6 +171,185 @@ class TestPlaylistDiff:
 
         for i, op in enumerate(ops.ops):
             assert ops[i] == op
+
+
+class TrackStub:
+    """Minimal stub for testing partial matching by ID."""
+
+    def __init__(self, track_id: str, title: str = "") -> None:
+        self.track_id = track_id
+        self.title = title
+
+    def __repr__(self) -> str:
+        return f"TrackStub({self.track_id!r}, {self.title!r})"
+
+
+class TestListDiffEq:
+    """Tests for list_diff_eq with equality-based partial matching."""
+
+    @staticmethod
+    def _ops_equal(
+        actual: list[Op],
+        expected: list[Op],
+        eq_func: Callable[[object, object], bool],
+    ) -> bool:
+        """Compare operation lists using eq_func for item fields."""
+        if len(actual) != len(expected):
+            return False
+        for a, e in zip(actual, expected):
+            if type(a) is not type(e):
+                return False
+            if isinstance(a, DeleteOp) and isinstance(e, DeleteOp):
+                if a.idx != e.idx or not eq_func(a.item, e.item):
+                    return False
+            elif isinstance(a, InsertOp) and isinstance(e, InsertOp):
+                if a.idx != e.idx or not eq_func(a.item, e.item):
+                    return False
+            elif isinstance(a, MoveOp) and isinstance(e, MoveOp):
+                if (
+                    a.old_idx != e.old_idx
+                    or a.new_idx != e.new_idx
+                    or not eq_func(a.item, e.item)
+                ):
+                    return False
+            else:
+                return False
+        return True
+
+    @staticmethod
+    def _round_trip(
+        old: list,
+        new: list,
+        ops: Operations,
+        eq_func: Callable[[object, object], bool],
+    ) -> None:
+        """Verify that applying operations reconstructs the target list."""
+        playlist = old.copy()
+        for step in ops.iter():
+            op = step.op
+            if isinstance(op, DeleteOp):
+                playlist.pop(op.idx)
+            elif isinstance(op, InsertOp):
+                playlist.insert(op.idx, op.item)
+            elif isinstance(op, MoveOp):
+                val = playlist.pop(op.old_idx)
+                playlist.insert(op.new_idx, val)
+            else:
+                raise ValueError(f"Unknown operation: {op}")
+        assert len(playlist) == len(new), (
+            f"Length mismatch: {len(playlist)} != {len(new)}"
+        )
+        for a, b in zip(playlist, new):
+            assert eq_func(a, b), f"Item mismatch: {a!r} != {b!r}"
+
+    @pytest.mark.parametrize(
+        "old, new, expected",
+        [
+            # --- Parity with list_diff (eq_func == equality) ---
+            pytest.param([], [], [], id="empty_to_empty"),
+            pytest.param(["A"], ["A"], [], id="single_identical"),
+            pytest.param(["A", "B", "C"], ["A", "B", "C"], [], id="identical_lists"),
+            pytest.param([], ["A"], [InsertOp(idx=0, item="A")], id="insert_single"),
+            pytest.param(["A"], [], [DeleteOp(idx=0, item="A")], id="delete_single"),
+            pytest.param(
+                ["A", "A"], ["A"], [DeleteOp(idx=1, item="A")], id="delete_duplicate"
+            ),
+            pytest.param(
+                ["A"], ["A", "A"], [InsertOp(idx=1, item="A")], id="insert_duplicate"
+            ),
+            pytest.param(
+                ["A", "B", "C"],
+                ["C", "A", "B"],
+                [MoveOp(old_idx=2, new_idx=0, item="C")],
+                id="move_last_to_front",
+            ),
+            pytest.param(
+                ["A", "B"],
+                ["B", "A"],
+                [MoveOp(old_idx=1, new_idx=0, item="B")],
+                id="swap_two",
+            ),
+            pytest.param(
+                ["A", "B", "C", "D"],
+                ["B", "D", "A", "C"],
+                [
+                    MoveOp(old_idx=1, new_idx=0, item="B"),
+                    MoveOp(old_idx=3, new_idx=1, item="D"),
+                ],
+                id="complex_reorder",
+            ),
+            # --- Partial matching: match by ID, different title ---
+            pytest.param(
+                [TrackStub("1", "Old Title")],
+                [TrackStub("1", "New Title")],
+                [],
+                id="partial_match_same_id_different_title",
+            ),
+            # --- Partial matching: IDs determine moves ---
+            pytest.param(
+                [TrackStub("1"), TrackStub("2")],
+                [TrackStub("2"), TrackStub("1")],
+                [MoveOp(old_idx=1, new_idx=0, item=TrackStub("2"))],
+                id="partial_swap_by_id",
+            ),
+            # --- Partial matching: delete unmatched, insert new ---
+            pytest.param(
+                [TrackStub("1"), TrackStub("2"), TrackStub("3")],
+                [TrackStub("2"), TrackStub("4")],
+                [
+                    DeleteOp(idx=2, item=TrackStub("3")),
+                    DeleteOp(idx=0, item=TrackStub("1")),
+                    InsertOp(idx=1, item=TrackStub("4")),
+                ],
+                id="partial_delete_and_insert",
+            ),
+            # --- Partial matching: keep first occurrence when duplicates ---
+            pytest.param(
+                [TrackStub("1", "a"), TrackStub("1", "b")],
+                [TrackStub("1", "c")],
+                [DeleteOp(idx=1, item=TrackStub("1", "b"))],
+                id="partial_duplicate_keep_first",
+            ),
+            # --- Full mix with partial matching ---
+            pytest.param(
+                [
+                    TrackStub("1", "foo"),
+                    TrackStub("2", "bar"),
+                    TrackStub("3", "baz"),
+                    TrackStub("4", "qux"),
+                ],
+                [
+                    TrackStub("3", "baz-new"),
+                    TrackStub("5", "new"),
+                    TrackStub("1", "foo-new"),
+                    TrackStub("2", "bar"),
+                ],
+                [
+                    DeleteOp(idx=3, item=TrackStub("4", "qux")),
+                    MoveOp(old_idx=2, new_idx=0, item=TrackStub("3", "baz")),
+                    InsertOp(idx=1, item=TrackStub("5", "new")),
+                ],
+                id="partial_full_mix",
+            ),
+        ],
+    )
+    def test_list_diff_eq(self, old, new, expected):
+        """Test list_diff_eq with both simple values and partial matching."""
+        if old and isinstance(old[0], TrackStub):
+
+            def eq_func(a, b):
+                return a.track_id == b.track_id
+        else:
+
+            def eq_func(a, b):
+                return a == b
+
+        ops = list_diff_eq(old, new, eq_func)
+        applied_ops = [op.op for op in ops.iter()]
+        assert self._ops_equal(applied_ops, expected, eq_func), (
+            f"Expected {expected}, got {applied_ops}"
+        )
+        self._round_trip(old, new, ops, eq_func)
 
 
 class TestBatchConsecutive:

--- a/tests/core/test_ids.py
+++ b/tests/core/test_ids.py
@@ -141,7 +141,7 @@ class TestTrackIDRepr:
     """The ABC __repr__ is only used by non-dataclass subclasses."""
 
     def test_track_id_repr(self):
-        class _Minimal(TrackID):
+        class _Minimal(TrackID, service="test"):
             @classmethod
             def parse(cls, value: str):
                 return cls()
@@ -153,7 +153,7 @@ class TestTrackIDRepr:
         assert repr(_Minimal()) == "_Minimal(serial='test:123')"
 
     def test_playlist_id_repr(self):
-        class _Minimal(PlaylistID):
+        class _Minimal(PlaylistID, service="test"):
             @classmethod
             def parse(cls, value: str):
                 return cls()

--- a/tests/core/test_matching.py
+++ b/tests/core/test_matching.py
@@ -1,7 +1,8 @@
 import pytest
 
-from plistsync.core.collection import Matches, TrackInfo
+from plistsync.core.collection import Matches
 from plistsync.core.matching import distance, fuzzy_match
+from plistsync.core.track import TrackInfo
 
 from .mock_track import MockTrack
 

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -1,9 +1,9 @@
-from typing import Any
+from __future__ import annotations
+from typing import Any, TYPE_CHECKING
 from unittest.mock import ANY, Mock
 import pytest
 from plistsync.core.ids import ISRC
 from plistsync.core.playlist import (
-    MultiRequestServicePlaylist,
     OfflinePlaylist,
     PlaylistInfo,
     Snapshot,
@@ -18,6 +18,11 @@ from ..abc.playlist import (
     TestMultiRequestServicePlaylistBase,
     TestServicePlaylistBase,
 )
+
+if TYPE_CHECKING:
+    from plistsync.core.playlist import (
+        MultiRequestServicePlaylist,
+    )
 
 
 class TestOfflinePlaylist(TestPlaylistBase):
@@ -85,6 +90,24 @@ class TestMockMultiRequestServicePlaylist(TestMultiRequestServicePlaylistBase):
         )
         playlist._remote_insert_track.assert_called_once_with(
             idx=0, track=4, tracks_before=ANY
+        )
+
+    def test_default_remote_move_track_downwards(
+        self, playlist: MultiRequestServicePlaylist
+    ):
+        """Moving a track to a higher index inserts at new_idx after removal."""
+        playlist._remote_insert_track = Mock()
+        playlist._remote_delete_track = Mock()
+
+        playlist._remote_move_track(
+            old_idx=0, new_idx=2, track=3, tracks_before=[3, 4, 5]
+        )
+
+        playlist._remote_delete_track.assert_called_once_with(
+            idx=0, track=3, tracks_before=ANY
+        )
+        playlist._remote_insert_track.assert_called_once_with(
+            idx=2, track=3, tracks_before=ANY
         )
 
     def test_none_name_raises(self, playlist: MultiRequestServicePlaylist):

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -9,6 +9,7 @@ from plistsync.core.playlist import (
     Snapshot,
 )
 from plistsync.core.track import OfflineTrack
+from plistsync.services.spotify import SpotifyPlaylistID
 
 from ..core.mock_playlist import MockMultiRequestServicePlaylist, MockServicePlaylist
 from ..core.mock_track import MockTrack
@@ -23,7 +24,7 @@ class TestOfflinePlaylist(TestPlaylistBase):
     def create_playlist(self, name="Name", n_tracks=0):
         return OfflinePlaylist(
             info=PlaylistInfo(name=name, description="description"),
-            id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            id=SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
             tracks=[
                 OfflineTrack(info={"title": f"Track {i}"}, ids={ISRC(str(i))})
                 for i in range(n_tracks)
@@ -56,7 +57,7 @@ class TestMockServicePlaylist(TestServicePlaylistBase):
     def create_playlist(self, name="Name", n_tracks=0):
         return MockServicePlaylist(
             info=PlaylistInfo(name=name, description="description"),
-            id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            id=SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
             tracks=[MockTrack(ids={ISRC(str(i))}) for i in range(n_tracks)],
         )
 
@@ -65,7 +66,7 @@ class TestMockMultiRequestServicePlaylist(TestMultiRequestServicePlaylistBase):
     def create_playlist(self, name="Name", n_tracks=0):
         return MockMultiRequestServicePlaylist(
             info=PlaylistInfo(name=name, description="description"),
-            id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            id=SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
             tracks=[MockTrack(ids={ISRC(str(i))}) for i in range(n_tracks)],
         )
 

--- a/tests/services/beets/test_search.py
+++ b/tests/services/beets/test_search.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
 from pathlib import Path
-from beets.library import Library
 
 from plistsync.services.beets import BeetsDatabase, BeetsCollection
 
 from ._common import item
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from beets.library import Library
 
 
 def test_db_create(beets_lib):

--- a/tests/services/beets/test_track.py
+++ b/tests/services/beets/test_track.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import pytest
 
 from plistsync.services.beets.database import BeetsDatabase
@@ -10,7 +12,7 @@ from tests.services.beets._common import item
 
 class TestBeetsTrack(TestTrack):
     track_class = BeetsTrack
-    test_config = {
+    test_config: ClassVar[dict[str, bool]] = {
         "has_path": True,
     }
 

--- a/tests/services/local/test_collection.py
+++ b/tests/services/local/test_collection.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
 import pytest
-from pathlib import Path
 from tinytag import TinyTag
 
 from plistsync.core.ids import ISRC
 from plistsync.services.local.collection import LocalCollection
 
 from tests.conftest import set_tags
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_create(audio_files: Path):

--- a/tests/services/local/test_track.py
+++ b/tests/services/local/test_track.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 from plistsync.services.local import LocalTrack
@@ -8,7 +9,7 @@ from tests.conftest import set_tags
 
 class TestLocalTrack(TestTrack):
     track_class = LocalTrack
-    test_config = {
+    test_config: ClassVar[dict[str, bool]] = {
         "has_path": True,
     }
 

--- a/tests/services/plex/conftest.py
+++ b/tests/services/plex/conftest.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
 import pytest
 from unittest.mock import MagicMock, Mock
-from pathlib import Path
 from plistsync.services.plex.api import PlexApi
-from plistsync.services.plex.api_types import (
-    PlexApiPlaylistTrackResponse,
-    PlexApiTrackResponse,
-    PlexApiPlaylistResponse,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.services.plex.api_types import (
+        PlexApiPlaylistTrackResponse,
+        PlexApiTrackResponse,
+        PlexApiPlaylistResponse,
+    )
+    from pathlib import Path
 
 
 def side_effect_section_name_to_id(name):

--- a/tests/services/plex/test_playlist.py
+++ b/tests/services/plex/test_playlist.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
 from unittest.mock import Mock
 import pytest
-from plistsync.services.plex.api_types import (
-    PlexApiPlaylistResponse,
-    PlexApiPlaylistTrackResponse,
-)
 from plistsync.services.plex.playlist import PlexPlaylist, PlexPlaylistID
 from tests.abc.playlist import TestMultiRequestServicePlaylistBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.services.plex.api_types import (
+        PlexApiPlaylistResponse,
+        PlexApiPlaylistTrackResponse,
+    )
 
 
 class TestPlexPlaylist(TestMultiRequestServicePlaylistBase):

--- a/tests/services/plex/test_track.py
+++ b/tests/services/plex/test_track.py
@@ -1,5 +1,5 @@
-from pathlib import Path
-from typing import ClassVar
+from __future__ import annotations
+from typing import ClassVar, TYPE_CHECKING
 
 import pytest
 from plistsync.services.local.track import LocalTrack
@@ -8,10 +8,13 @@ from plistsync.services.plex.api_types import PlexApiTrackResponse
 from tests.abc.tracks import TestTrack
 from tests.conftest import set_tags
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 class TestPlexTrack(TestTrack):
     track_class = PlexTrack
-    test_config = {
+    test_config: ClassVar[dict[str, bool]] = {
         "has_path": True,
     }
 

--- a/tests/services/spotify/conftest.py
+++ b/tests/services/spotify/conftest.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
 import pytest
-from plistsync.services.spotify.api_types import SpotifyApiPlaylistResponseFull
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.services.spotify.api_types import SpotifyApiPlaylistResponseFull
 
 
 @pytest.fixture

--- a/tests/services/spotify/test_playlist.py
+++ b/tests/services/spotify/test_playlist.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
 from unittest.mock import Mock
 
 import pytest
-from plistsync.services.spotify.api_types import SpotifyApiPlaylistResponseFull
 from plistsync.services.spotify.playlist import SpotifyPlaylist, SpotifyPlaylistID
 from tests.abc.playlist import TestMultiRequestServicePlaylistBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.services.spotify.api_types import SpotifyApiPlaylistResponseFull
 
 
 class TestSpotifyPlaylist(TestMultiRequestServicePlaylistBase):

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable
-from typing import Any, Self
+from typing import Any, Self, TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from plistsync.core import Library, Track, TrackInfo
+from plistsync.core import Library, Track
 from plistsync.core.ids import PlaylistID, TrackID
 from plistsync.errors import DependencyError
 from plistsync.services import Service, ServiceLoader
 from plistsync.services.registry import Registry
+
+if TYPE_CHECKING:
+    from plistsync.core import TrackInfo
+    from collections.abc import Generator, Iterable
 
 SERVICE_MODULE = "plistsync.services._test"
 SERVICE_NAME = "_test"

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -1,69 +1,288 @@
 from __future__ import annotations
 
-import sys
-from types import ModuleType
+from abc import ABC, abstractmethod
+from collections.abc import Generator, Iterable
+from typing import Any, Self
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from plistsync.core import Library, Track, TrackInfo
+from plistsync.core.ids import PlaylistID, TrackID
 from plistsync.errors import DependencyError
-from plistsync.services import Service, ServiceRegistry
+from plistsync.services import Service, ServiceLoader
+from plistsync.services.registry import Registry
+
+SERVICE_MODULE = "plistsync.services._test"
+SERVICE_NAME = "_test"
 
 
-class TestDiscovery:
-    """ServiceRegistry discovers Service subclasses and infers names."""
+# ------------------------------ Test fixtures ------------------------------ #
+
+
+class Root(ABC, Registry):
+    """Independent registry root, so tests don't touch core abstractions."""
+
+
+class FakePlaylistID(PlaylistID):
+    __module__ = SERVICE_MODULE
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        return cls()
+
+    @property
+    def serial(self) -> str:
+        return f"{SERVICE_NAME}:playlist:fake"
+
+
+class FakeTrackID(TrackID):
+    __module__ = SERVICE_MODULE
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        return cls()
+
+    @property
+    def serial(self) -> str:
+        return f"{SERVICE_NAME}:track:fake"
+
+
+class FakeTrack(Track):
+    __module__ = SERVICE_MODULE
+
+    @property
+    def info(self) -> TrackInfo:
+        return {}
+
+    @property
+    def ids(self) -> frozenset[TrackID]:
+        return frozenset()
+
+
+class FakeLibrary(Library[Any, Any]):
+    __module__ = SERVICE_MODULE
+
+    @property
+    def playlists(self) -> Iterable[Any]:
+        return []
+
+    def get_playlist(self, *, id: PlaylistID | str | None = None) -> Any | None:
+        return None
+
+    def create_playlist(
+        self,
+        name: str,
+        description: str | None = None,
+        tracks: list[Any] | None = None,
+    ) -> Any:
+        raise NotImplementedError
+
+
+class FakeService(Service):
+    __module__ = SERVICE_MODULE
+
+
+@pytest.fixture(autouse=True)
+def isolate_registry() -> Generator[None, None, None]:
+    """Restore the global registry to its pre-test state.
+
+    Concrete classes register themselves at definition time into the global
+    ``Registry._REGISTRY``. Snapshot and restore it so classes defined inside
+    tests don't leak into other tests.
+    """
+    snapshot = {
+        root: {service: list(classes) for service, classes in bucket.items()}
+        for root, bucket in Registry._REGISTRY.items()
+    }
+    yield
+    Registry._REGISTRY.clear()
+    Registry._REGISTRY.update(snapshot)
+
+
+# ------------------------------- Test Registry ------------------------------ #
+
+
+class TestRegistry:
+    """Registry registers concrete subclasses by service at definition time."""
+
+    def test_concrete_subclasses_register_under_root(self) -> None:
+        class ImplA(Root):
+            __module__ = "plistsync.services._test_a"
+
+        class ImplB(Root):
+            __module__ = "plistsync.services._test_b"
+
+        assert Root.registry() == {"_test_a": [ImplA], "_test_b": [ImplB]}
+
+    def test_multiple_implementations_accumulate_per_service(self) -> None:
+        class ImplA(Root):
+            __module__ = SERVICE_MODULE
+
+        class ImplB(Root):
+            __module__ = SERVICE_MODULE
+
+        assert Root.registry()[SERVICE_NAME] == [ImplA, ImplB]
+
+    def test_explicit_service_kwarg_overrides_module_derivation(self) -> None:
+        class Impl(Root, service="custom"):
+            pass
+
+        assert Root.registry() == {"custom": [Impl]}
+
+    def test_abstract_root_is_not_registered(self) -> None:
+        assert Root.registry() == {}
+        assert Root._registry is Root
+
+    def test_abc_subclass_becomes_new_root(self) -> None:
+        class SubRoot(Root, ABC):
+            pass
+
+        class Impl(SubRoot):
+            __module__ = SERVICE_MODULE
+
+        assert SubRoot._registry is SubRoot
+        assert SubRoot.registry() == {SERVICE_NAME: [Impl]}
+        assert Root.registry() == {}
+
+    def test_subclass_with_abstract_methods_becomes_new_root(self) -> None:
+        class SubRoot(Root):
+            @abstractmethod
+            def abstract_meth(self) -> None: ...
+
+        class Impl(SubRoot):
+            __module__ = SERVICE_MODULE
+
+            def abstract_meth(self) -> None: ...
+
+        assert SubRoot.registry() == {SERVICE_NAME: [Impl]}
+        assert Root.registry() == {}
+
+    def test_service_derivation_fails_outside_services_namespace(self) -> None:
+        with pytest.raises(ValueError, match="Cannot derive service name"):
+
+            class ForeignImpl(Root):
+                pass
+
+    def test_direct_subclass_without_root_fails(self) -> None:
+        with pytest.raises(ValueError, match="does not define a registry key"):
+
+            class Orphan(Registry):
+                pass
+
+    def test_registry_accessor_without_root_fails(self) -> None:
+        with pytest.raises(ValueError, match="not defined"):
+            Registry.registry()
+
+
+# ------------------------------- Test Service ------------------------------- #
+
+
+class TestService:
+    """Service exposes the classes registered for its module-derived name."""
+
+    def test_name_inferred_from_module(self) -> None:
+        assert FakeService().name == SERVICE_NAME
+
+    def test_playlist_ids_returns_registered_classes(self) -> None:
+        assert list(FakeService().playlist_ids()) == [FakePlaylistID]
+
+    def test_track_ids_returns_registered_classes(self) -> None:
+        assert list(FakeService().track_ids()) == [FakeTrackID]
+
+    def test_tracks_returns_registered_classes(self) -> None:
+        assert list(FakeService().tracks()) == [FakeTrack]
+
+    def test_library_returns_registered_class(self) -> None:
+        assert FakeService().library() is FakeLibrary
+
+    def test_library_returns_none_when_unregistered(self) -> None:
+        class LibraryLessService(Service):
+            __module__ = "plistsync.services._test_nolib"
+
+        assert LibraryLessService().library() is None
+
+    def test_unregistered_service_lookups_return_empty(self) -> None:
+        class LonelyService(Service):
+            __module__ = "plistsync.services._test_lonely"
+
+        service = LonelyService()
+        assert service.playlist_ids() == ()
+        assert service.track_ids() == ()
+        assert service.tracks() == ()
+        assert service.library() is None
+
+
+# ----------------------------- Test ServiceLoader ---------------------------- #
+
+
+def _make_entry_point(name: str, loaded: type[Service]) -> MagicMock:
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = loaded
+    return ep
+
+
+class TestServiceLoader:
+    """ServiceLoader discovers services through entry points."""
 
     @pytest.fixture(autouse=True)
-    def clear_cache(self):
-        ServiceRegistry.get.cache_clear()
+    def clear_loader_cache(self) -> Generator[None, None, None]:
+        ServiceLoader.get.__func__.cache_clear()
+        ServiceLoader.all.__func__.cache_clear()
         yield
-        ServiceRegistry.get.cache_clear()
+        ServiceLoader.get.__func__.cache_clear()
+        ServiceLoader.all.__func__.cache_clear()
 
-    def test_get_service_returns_instance_with_correct_name(self):
-        """Discovered service has name matching its module."""
-        fake_module = ModuleType("plistsync.services._test_fake")
+    def test_get_returns_service_instance(self) -> None:
+        ep = _make_entry_point(SERVICE_NAME, FakeService)
+        with patch("plistsync.services.entry_points", return_value=[ep]):
+            service = ServiceLoader.get(SERVICE_NAME)
 
-        class FakeService(Service):
-            track_cls = int  # type: ignore[assignment]
+        assert isinstance(service, FakeService)
+        assert service.name == SERVICE_NAME
+        ep.load.assert_called_once()
 
-        FakeService.__module__ = "plistsync.services._test_fake"
-        fake_module.FakeService = FakeService  # type: ignore[assignment]
+    def test_get_returns_none_for_unknown_service(self) -> None:
+        with patch("plistsync.services.entry_points", return_value=[]):
+            assert ServiceLoader.get("_nonexistent") is None
 
-        with patch.object(
-            sys, "modules", {**sys.modules, fake_module.__name__: fake_module}
-        ):
-            with patch("importlib.import_module", return_value=fake_module):
-                service = ServiceRegistry.get("_test_fake")
+    def test_get_returns_none_when_dependencies_missing(self) -> None:
+        ep = _make_entry_point("_test_broken", FakeService)
+        ep.load.side_effect = DependencyError("_test_broken", ["missing_pkg"])
+        with patch("plistsync.services.entry_points", return_value=[ep]):
+            assert ServiceLoader.get("_test_broken") is None
 
-        assert service is not None
-        assert service.name == "_test_fake"
+    def test_get_returns_none_when_module_missing(self) -> None:
+        ep = _make_entry_point("_test_broken", FakeService)
+        ep.load.side_effect = ModuleNotFoundError("No module named 'missing_pkg'")
+        with patch("plistsync.services.entry_points", return_value=[ep]):
+            assert ServiceLoader.get("_test_broken") is None
 
-    def test_get_service_returns_none_for_missing_dependency(self):
-        with patch(
-            "importlib.import_module",
-            side_effect=DependencyError("svc", ["pkg"]),
-        ):
-            assert ServiceRegistry.get("svc") is None
+    def test_all_returns_mapping_of_available_services(self) -> None:
+        class OtherService(Service):
+            __module__ = "plistsync.services._test_other"
 
-    def test_get_service_returns_none_when_no_service_subclass(self):
-        empty = ModuleType("plistsync.services._test_empty")
-        with patch.object(sys, "modules", {**sys.modules, empty.__name__: empty}):
-            with patch("importlib.import_module", return_value=empty):
-                assert ServiceRegistry.get("_test_empty") is None
+        eps = [
+            _make_entry_point(SERVICE_NAME, FakeService),
+            _make_entry_point("_test_other", OtherService),
+        ]
+        with patch("plistsync.services.entry_points", return_value=eps):
+            result = ServiceLoader.all()
 
-    def test_dict_keys_are_module_names(self):
-        result = ServiceRegistry.dict()
-        for name in result:
-            assert result[name].name == name
+        assert set(result) == {SERVICE_NAME, "_test_other"}
+        assert isinstance(result[SERVICE_NAME], FakeService)
+        assert isinstance(result["_test_other"], OtherService)
+        for name, service in result.items():
+            assert service.name == name
 
-    def test_dict_filters_broken_modules(self):
-        with patch(
-            "pkgutil.iter_modules",
-            return_value=[MagicMock(name="_test_broken")],
-        ):
-            with patch(
-                "importlib.import_module",
-                side_effect=DependencyError("_test_broken", ["pkg"]),
-            ):
-                result = ServiceRegistry.dict()
+    def test_all_skips_services_with_missing_dependencies(self) -> None:
+        good = _make_entry_point(SERVICE_NAME, FakeService)
+        broken = _make_entry_point("_test_broken", FakeService)
+        broken.load.side_effect = DependencyError("_test_broken", ["missing_pkg"])
+
+        with patch("plistsync.services.entry_points", return_value=[good, broken]):
+            result = ServiceLoader.all()
+
+        assert SERVICE_NAME in result
         assert "_test_broken" not in result

--- a/tests/services/tidal/test_playlist.py
+++ b/tests/services/tidal/test_playlist.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
 from unittest.mock import Mock
 
 import pytest
-from plistsync.services.tidal.api_types import PlaylistResource
 from plistsync.services.tidal.playlist import TidalPlaylist, TidalPlaylistID
 from tests.abc.playlist import TestMultiRequestServicePlaylistBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.services.tidal.api_types import PlaylistResource
 
 
 class TestsTidalPlaylist(TestMultiRequestServicePlaylistBase):

--- a/tests/services/traktor/test_collection.py
+++ b/tests/services/traktor/test_collection.py
@@ -10,7 +10,10 @@ from plistsync.services.traktor.utility import xpath_string_escape
 from tests.abc.collection import CollectionTestBase, LibraryCollectionTestBase
 
 from lxml import etree
-from lxml.etree import _Element
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
 
 
 class TestNMLLibrary(LibraryCollectionTestBase):
@@ -345,7 +348,7 @@ class TestNMLPlaylist(CollectionTestBase):
         assert p1 is not None
 
         # Test with a valid traktor path
-        example_path = "D:/:SYNC/:library/:Amoss, Fre4knc/:Watermark Volume 2/:04 Dragger [1028kbps].flac"  # noqa: E501
+        example_path = "D:/:SYNC/:library/:Amoss, Fre4knc/:Watermark Volume 2/:04 Dragger [1028kbps].flac"
         track = p1.find_by_traktor_path(NMLPath(example_path))
         assert track is not None
 

--- a/tests/services/traktor/test_playlist.py
+++ b/tests/services/traktor/test_playlist.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
 import logging
 from uuid import UUID
 
 import pytest
-from plistsync.services.traktor import NMLPlaylist, NMLLibrary
 from plistsync.services.traktor.playlist import NMLPlaylistID
 from tests.abc.playlist import (
     TestServicePlaylistBase,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plistsync.services.traktor import NMLPlaylist, NMLLibrary
 
 
 class TestsTidalPlaylist(TestServicePlaylistBase):

--- a/tests/services/traktor/test_track.py
+++ b/tests/services/traktor/test_track.py
@@ -1,4 +1,5 @@
 from pathlib import PurePosixPath, PureWindowsPath
+from typing import ClassVar
 import pytest
 
 from plistsync.services.traktor import NMLTrack
@@ -10,7 +11,7 @@ from tests.abc.tracks import TestTrack
 
 class TestNMLTrack(TestTrack):
     track_class = NMLTrack
-    test_config = {
+    test_config: ClassVar[dict[str, bool]] = {
         "has_path": True,
     }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,13 @@
-from pathlib import Path
+from __future__ import annotations
 from unittest.mock import patch
 from plistsync.errors import ConfigurationError
 import pytest
 import os
 from plistsync.config import Config
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR uses the new fugue logic to enable bidirectional sync between mulitple service playlists


ToDo:
- [x] Agree on Naming
- [x] ~~Example~~ Later
- [x] Sync plist name and description (via lww register)
- [x] Tests
- [x] Changelog
- [x] ~~Serialization~~ (Moved to #104) 