### PR TITLE
Improved registry-based service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - Refactored track identifier handling across the codebase by replacing service-specific `TrackIds` dictionaries with strongly typed, immutable `TrackID` dataclasses for each service (e.g. Spotify, Plex).
-- Refactored playlist identifier handling across the codebase by replacing service-specific `PlaylistIds` dictionaries with strongly typed, immutable `PlaylistID` dataclasses for each service (e.g. Spotify, Plex). 
+- Refactored playlist identifier handling across the codebase by replacing service-specific `PlaylistIds` dictionaries with strongly typed, immutable `PlaylistID` dataclasses for each service (e.g. Spotify, Plex).
   - Removed obsolete playlist ID extraction utilities that are no longer required under the new identifier system.
   - Updated all playlist operations and internal synchronization flows to use the new typed identifier model consistently.
 
 This improves type safety, clarity, and extensibility for playlist identification and lookup operations. All playlist-related APIs and synchronization logic now operate on explicit identifier types instead of loosely structured dictionaries.
 
+- Replaced the import-based `ServiceRegistry` with entry-point based service discovery via `ServiceLoader` (`ServiceLoader.get(name)` / `ServiceLoader.all()`). Services are now discovered through the `plistsync.services` entry-point group without importing all service modules, and services with missing optional dependencies are skipped gracefully.
+- Removed the `track_cls`, `library_cls`, `playlist_cls` and `playlist_id_cls` attributes from `Service` implementations; registered classes are resolved through the `Registry` instead.
+- `OfflinePlaylist` now takes a typed `PlaylistID` (`id=...`) instead of an `id_serial` string.
+
 ### Added
 
-- Added typed `Service` marker class with `track_cls`, `library_cls`, `playlist_cls` attributes and module-inferred `name` property, enabling single-handle access to all a service's core types. (#95)
+- Added typed `Service` marker class with a module-inferred `name` property and registry-backed accessors (`library()`, `tracks()`, `track_ids()`, `playlist_ids()`), enabling single-handle access to all a service's core types. (#95)
+- Added generic `Registry` base class that auto-registers concrete implementations by service name at class-definition time. `Track`, `Library`, `TrackID`, and `PlaylistID` are now registry roots, making service classes discoverable simply by importing their module.
 - Added a migration example to fully copy a playlist from an arbitrary service to another. (#60)
 
 ### Fixed

--- a/examples/community/migrate.py
+++ b/examples/community/migrate.py
@@ -138,6 +138,8 @@ def main(
         ),
     ] = True,
 ):
+    # Due to service loader, no `import service_xyz` satements are needed
+    # services are fetched lazily
     if not (_from_service := ServiceLoader.get(from_service.lower())):
         log.error(
             f"Invalid from_service {from_service!r}.\n"

--- a/examples/community/migrate.py
+++ b/examples/community/migrate.py
@@ -12,7 +12,7 @@ import typer
 
 from plistsync.core import Library, Matches, ServicePlaylist, Track
 from plistsync.logger import log
-from plistsync.services import ServiceRegistry
+from plistsync.services import ServiceLoader
 
 
 class MigrationContext(NamedTuple):
@@ -138,28 +138,28 @@ def main(
         ),
     ] = True,
 ):
-    if not (_from_service := ServiceRegistry.get(from_service.lower())):
+    if not (_from_service := ServiceLoader.get(from_service.lower())):
         log.error(
             f"Invalid from_service {from_service!r}.\n"
-            f"Pick one of {list(ServiceRegistry.dict().keys())}"
+            f"Pick one of {list(ServiceLoader.all().keys())}"
         )
         sys.exit(1)
 
-    if _from_service.library_cls is None:
+    if (from_library_cls := _from_service.library()) is None:
         log.error(
             f"Invalid from_service {_from_service}.\n"
             "Does not support library based operations."
         )
         sys.exit(1)
 
-    if not (_to_service := ServiceRegistry.get(to_service.lower())):
+    if not (_to_service := ServiceLoader.get(to_service.lower())):
         log.error(
             f"Invalid to_service {to_service!r}.\n"
-            f"Pick one of {list(ServiceRegistry.dict().keys())}."
+            f"Pick one of {list(ServiceLoader.all().keys())}."
         )
         sys.exit(1)
 
-    if _to_service.library_cls is None:
+    if (to_library_cls := _to_service.library()) is None:
         log.error(
             f"Invalid to_service {_to_service}.\n"
             "Does not support library based operations."
@@ -171,8 +171,8 @@ def main(
         sys.exit(1)
 
     migrate_library(
-        _from_service.library_cls(),
-        _to_service.library_cls(),
+        from_library_cls(),
+        to_library_cls(),
         MigrationContext(overwrite=overwrite, skip_empty=skip_empty),
     )
 

--- a/plistsync/__main__.py
+++ b/plistsync/__main__.py
@@ -7,7 +7,7 @@ import typer
 from eyconf.cli import create_config_cli
 from rich.logging import RichHandler
 
-from plistsync.services import ServiceRegistry
+from plistsync.services import ServiceLoader
 
 from .config import Config
 from .errors import DependencyError
@@ -110,7 +110,7 @@ def version_callback(value: bool) -> None:
     from importlib.metadata import version
 
     ver = version("plistsync")
-    services = [service for service in ServiceRegistry.dict().keys()]
+    services = [service for service in ServiceLoader.all().keys()]
 
     svc_str = ", ".join(services) if services else "none"
     typer.echo(f"plistsync: {ver}  ({svc_str})")

--- a/plistsync/core/collection.py
+++ b/plistsync/core/collection.py
@@ -56,6 +56,8 @@ from typing import (
 
 from typing_extensions import TypeVar
 
+from plistsync.services.registry import Registry
+
 from .ids import Scope, TrackID
 from .matching import Matches, Similarity, fuzzy_match
 from .track import Track, TrackInfo
@@ -363,7 +365,7 @@ class Collection(ABC, Generic[T]):
         )
 
 
-class Library(Generic[T, Plist], Collection[T]):
+class Library(Generic[T, Plist], Collection[T], ABC, Registry):
     """Represents a collection of tracks in a library with playlist management.
 
     This class serves as a base for library collections across diverse services.

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -5,9 +5,11 @@ from enum import Enum
 from pathlib import PurePath
 from typing import ClassVar, Self
 
+from plistsync.services.registry import Registry
+
 
 @dataclass(frozen=True)
-class PlaylistID(ABC):
+class PlaylistID(ABC, Registry):
     """Immutable base for service-specific playlist identifiers.
 
     Decouples the service-specific representation from the generic playlist
@@ -60,7 +62,7 @@ class Scope(Enum):
 
 
 @dataclass(frozen=True)
-class TrackID(ABC):
+class TrackID(ABC, Registry):
     """Immutable base for service-specific track identifiers.
 
     Decouples the service-specific representation from the generic track
@@ -108,7 +110,7 @@ class TrackID(ABC):
 
 
 @dataclass(frozen=True)
-class ISRC(TrackID):
+class ISRC(TrackID, service="core"):
     """International Standard Recording Code.
 
     A standardized identifier intended to be globally unique for a recording.
@@ -152,7 +154,7 @@ class ISRC(TrackID):
 
 
 @dataclass(frozen=True)
-class FilePath(TrackID):
+class FilePath(TrackID, service="core"):
     """File path identifier for local tracks.
 
     This is a simple wrapper around a file path, used to identify local tracks in a

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -454,46 +454,29 @@ class OfflinePlaylist(Playlist[OfflineTrack], service="core"):
 
     _tracks: list[OfflineTrack]
     _info: PlaylistInfo
-    _id_serial: str
+    _id: PlaylistID
 
     def __init__(
         self,
-        id_serial: str,
+        id: PlaylistID,
         info: PlaylistInfo,
         tracks: Sequence[OfflineTrack] | None = None,
     ) -> None:
         self._info = info
         self._tracks = list(tracks or [])
-        self._id_serial = id_serial
+        self._id = id
 
     @classmethod
     def from_playlist(cls, playlist: Playlist) -> OfflinePlaylist:
         return OfflinePlaylist(
-            id_serial=playlist.id.serial,
+            id=playlist.id,
             info=copy(playlist.info),
             tracks=[OfflineTrack.from_track(t) for t in playlist.tracks],
         )
 
     @property
     def id(self) -> PlaylistID:
-        """PlaylistID retreived from serializid string."""
-
-        from plistsync.services import ServiceRegistry
-
-        colon_idx = self._id_serial.find(":")
-        if colon_idx == -1:
-            raise ValueError(
-                f"Cannot determine service for serial: {self._id_serial!r}"
-            )
-        service_str = self._id_serial[:colon_idx]
-
-        if not (service := ServiceRegistry.get(service_str)):
-            raise ValueError(f"Unknown service {service!r} in OfflinePlaylistID")
-
-        if not (playlist_id_cls := service.playlist_id_cls):
-            raise ValueError(f"Service {service!r} has no PlalistID class registered")
-
-        return playlist_id_cls.parse(self._id_serial)
+        return self._id
 
     @property
     def info(self) -> PlaylistInfo:

--- a/plistsync/core/playlist.py
+++ b/plistsync/core/playlist.py
@@ -28,6 +28,8 @@ from typing import Generic, Self, TypedDict
 
 from typing_extensions import TypeVar
 
+from plistsync.services.registry import Registry
+
 from .collection import Collection, Library, TrackStream
 from .diff import DeleteOp, InsertOp, MoveOp, batch_consecutive, list_diff
 from .ids import PlaylistID
@@ -68,7 +70,7 @@ class Snapshot(Generic[T]):
     tracks: list[T]
 
 
-class Playlist(Generic[T], Collection[T], TrackStream[T], ABC):
+class Playlist(Generic[T], Collection[T], TrackStream[T], ABC, Registry):
     """Abstract base class defining the core playlist interface.
 
     This class provides a minimal protocol for playlist-like objects without
@@ -441,7 +443,7 @@ class MultiRequestServicePlaylist(ServicePlaylist[T], ABC):
 # TODO: We should move this into another file
 
 
-class OfflinePlaylist(Playlist[OfflineTrack]):
+class OfflinePlaylist(Playlist[OfflineTrack], service="core"):
     """A offline (in memory) playlist with no service synchronization.
 
     This class provides a concrete implementation of `Playlist` for

--- a/plistsync/core/track.py
+++ b/plistsync/core/track.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 
 from plistsync.core.ids import ISRC, FilePath, TrackID
 from plistsync.logger import log
+from plistsync.services.registry import Registry
 
 
 class TrackInfo(TypedDict, total=False):
@@ -27,7 +28,7 @@ class TrackInfo(TypedDict, total=False):
     # convention, likely close to beets.
 
 
-class Track(ABC):
+class Track(ABC, Registry):
     """An abstract class representing a track.
 
     A track is a piece of music. It has a title, artists, albums and identifiers.
@@ -148,7 +149,7 @@ class Track(ABC):
         return f"{cls}(artist={artist!r}, title={title!r})"
 
 
-class OfflineTrack(Track):
+class OfflineTrack(Track, service="core"):
     """A offline (in memory) track with attached service.
 
     This class provides a concrete implementation of `Track` for

--- a/plistsync/errors.py
+++ b/plistsync/errors.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 
 from eyconf.validation import ConfigurationError, MultiConfigurationError
 
@@ -57,12 +57,12 @@ def check_imports(
             package.split("[")[0].split("<")[0].split(">")[0].split("=")[0].strip()
         )
 
-        try:
-            importlib.import_module(base_package)
-        except ImportError:
+        if importlib.util.find_spec(base_package) is None:
             missing.append(package)
 
     if missing:
         raise DependencyError(
-            service=service, missing_packages=missing, extra_name=extra_name
+            service=service,
+            missing_packages=missing,
+            extra_name=extra_name,
         )

--- a/plistsync/services/__init__.py
+++ b/plistsync/services/__init__.py
@@ -1,81 +1,114 @@
 # We do not import from the different submodules as they
 # might raise with check_dependencies.
 
-import importlib
-import inspect
-import pkgutil
-from abc import ABC
-from functools import cache
-from typing import ClassVar
+from __future__ import annotations
 
-from plistsync.core import Library, Playlist, PlaylistID, Track
+from abc import ABC
+from collections.abc import Sequence
+from functools import cache
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
 from plistsync.errors import DependencyError
 
+from .registry import Registry
 
-class Service(ABC):
+if TYPE_CHECKING:
+    from plistsync.core import Library, Track
+    from plistsync.core.ids import PlaylistID, TrackID
+
+
+class Service(ABC, Registry):
     """Abstraction for discoverable service plugins.
 
-    Subclasses in `services/<name>/` modules are automatically
-    discovered by the ServiceRegistry.
+    Concrete service implementations register their identifier classes at
+    class-definition time. Importing a service module is sufficient to make
+    its classes discoverable.
 
-    Each concrete Service exposes the key types that belong to its
-    service: the library/collection class and the track class.
-    Optionally a playlist class for playlist-capable services.
+    Each service exposes the identifier classes associated with it, including
+    track identifiers and optionally playlist identifiers.
     """
-
-    track_cls: ClassVar[type[Track]]
-    library_cls: ClassVar[type[Library] | None] = None
-    playlist_cls: ClassVar[type[Playlist] | None] = None
-    playlist_id_cls: ClassVar[type[PlaylistID] | None] = None
 
     @property
     def name(self) -> str:
         """Service name, inferred from the module (e.g. 'spotify', 'plex')."""
         return self.__module__.split(".")[-1]
 
+    def playlist_ids(self) -> Sequence[type[PlaylistID]]:
+        """Return playlist identifier classes registered for this service."""
 
-class ServiceRegistry:
-    """Central registry for dynamic service discovery and instantiation.
+        from plistsync.core.ids import PlaylistID
 
-    Automatically discovers Service subclasses in services/* modules
-    using pkgutil + importlib. Lazy-loaded with @cache for performance.
-    Handles missing dependencies gracefully.
+        return PlaylistID.registry().get(self.name, ())
 
-    Usage:
-        >>> service = ServiceRegistry.get_service('spotify')
-        >>> services = ServiceRegistry.list()  # {'spotify': SpotifyService(), ...}
+    def track_ids(self) -> Sequence[type[TrackID]]:
+        """Return track identifier classes registered for this service."""
+
+        from plistsync.core.ids import TrackID
+
+        return TrackID.registry().get(self.name, ())
+
+    def library(self) -> type[Library] | None:
+        """Return the library class registered for this service, if any."""
+        from plistsync.core import Library
+
+        return Library.registry().get(self.name, (None,))[0]
+
+    def tracks(self) -> Sequence[type[Track]]:
+        """Return the track class registered for this service, if any."""
+        from plistsync.core import Track
+
+        return Track.registry().get(self.name, ())
+
+
+class ServiceLoader:
+    """Lazy access to discoverable services specific classes."""
+
+    GROUP = "plistsync.services"
+    """Entry point group for discoverable services. Defined in the pyproject.toml to
+    allow registering a service.
+
+    This improves discoverability and avoids importing service modules just to check if
+    they exist, which is pretty slow.
     """
 
     @classmethod
     @cache
     def get(cls, name: str) -> Service | None:
-        """Dynamically import services.NAME module, find Service ABC, instantiate."""
+        """Load and return a service by name.
+
+        Importing the service module triggers class registration. Returns
+        ``None`` if the service cannot be imported or no service class exists.
+        """
+        eps = entry_points(
+            group=cls.GROUP,
+            name=name,
+        )
+
+        if not eps:
+            return None
         try:
-            module = importlib.import_module(f"{__name__}.{name}")
+            service_cls = list(eps)[0].load()
         except (DependencyError, ModuleNotFoundError):
             return None
 
-        # Find first Service subclass (assumes 1/module)
-        service_cls: None | type[Service] = None
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if issubclass(obj, Service) and obj != Service:
-                service_cls = obj
-                break
-
-        return service_cls() if service_cls else None
+        return service_cls()
 
     @classmethod
     @cache
-    def dict(cls) -> dict[str, Service]:
-        """All importable services {name: instance}.
+    def all(cls) -> dict[str, Service]:
+        """Return a mapping of service names to service instances.
 
-        Scans services/* modules via pkgutil, filters valid ones.
+        This will import all available service modules to trigger registration.
         """
         services: dict[str, Service] = {}
-        # REQUIRES: ServiceRegistry in package with __path__ (services/__init__.py)
-        for module_info in pkgutil.iter_modules(__path__, __name__ + "."):
-            short_name = module_info.name.rsplit(".", 1)[-1]
-            service = cls.get(short_name)
-            if service is not None:
-                services[short_name] = service
+
+        for ep in entry_points(group=cls.GROUP):
+            try:
+                service_cls: type[Service] = ep.load()
+            except (DependencyError, ModuleNotFoundError):
+                continue
+
+            services[ep.name] = service_cls()
+
         return services

--- a/plistsync/services/beets/__init__.py
+++ b/plistsync/services/beets/__init__.py
@@ -12,7 +12,7 @@ from .track import BeetsTrack
 
 
 class BeetsService(Service):
-    track_cls = BeetsTrack
+    pass
 
 
 __all__ = [

--- a/plistsync/services/local/__init__.py
+++ b/plistsync/services/local/__init__.py
@@ -11,7 +11,7 @@ from .track import LocalTrack
 
 
 class LocalService(Service):
-    track_cls = LocalTrack
+    pass
 
 
 __all__ = [

--- a/plistsync/services/plex/__init__.py
+++ b/plistsync/services/plex/__init__.py
@@ -13,10 +13,7 @@ from .track import PlexTrack, PlexTrackID
 
 
 class PlexService(Service):
-    library_cls = PlexLibrary
-    track_cls = PlexTrack
-    playlist_cls = PlexPlaylist
-    playlist_id_cls = PlexPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/registry.py
+++ b/plistsync/services/registry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import inspect
+from abc import ABC
+from functools import cache
+from typing import ClassVar, Self
+
+
+class Registry:
+    """Automatically register concrete subclasses by service.
+
+    Each abstract subclass of :class:`Registry` defines its own independent
+    registry. Concrete implementations are automatically registered when the
+    class is created.
+
+    The service name is derived from the module path::
+
+        plistsync.services.<service>.*
+
+    Subclasses may override this by providing an explicit ``service`` value.
+
+    Example:
+
+        .. code-block:: python
+
+            class PlaylistId(ABC, Registry):
+                ...
+
+            # plistsync.services.spotify.ids
+            class SpotifyPlaylistId(PlaylistId):
+                ...
+
+            # plistsync.services.apple.ids
+            class ApplePlaylistId(PlaylistId):
+                ...
+
+            PlaylistId.registry() == {
+                "spotify": [SpotifyPlaylistId],
+                "apple": [ApplePlaylistId],
+            }
+
+    Abstract subclasses become registry roots and are not registered
+    themselves. Only concrete subclasses are added to the registry.
+    """
+
+    _REGISTRY: ClassVar[dict[type, dict[str, list[type]]]] = {}
+    """Global registry for storing **all** registered classes."""
+
+    _registry: ClassVar[type[Registry] | None] = None
+    """Semi global registry key for this class and its subclasses.
+    Subclasses must define this but this can be overridden in subclasses to
+    register under a different key."""
+
+    def __init_subclass__(
+        cls,
+        *,
+        service: str | None = None,
+        **kwargs,
+    ):
+        super().__init_subclass__(**kwargs)
+
+        # Abstract bases become the registry key for their concrete subclasses.
+        if inspect.isabstract(cls) or ABC in cls.__bases__:
+            cls._registry = cls
+            return
+
+        if cls._registry is None:
+            raise ValueError(
+                f"Cannot register {cls.__name__!r}, it does not define a registry key."
+            )
+
+        service_name = service or cls.service()
+
+        registry_bucket = cls._REGISTRY.setdefault(cls._registry, {})
+        registry_bucket.setdefault(service_name, []).append(cls)
+
+    @classmethod
+    @cache
+    def service(cls) -> str:
+        """Return the service name for this class."""
+        module_str = cls.__module__
+        if not module_str.startswith("plistsync.services."):
+            raise ValueError(f"Cannot derive service name for {cls.__name__!r}")
+
+        return module_str.split(".")[2]
+
+    @classmethod
+    def registry(cls) -> dict[str, list[type[Self]]]:
+        """Return the registry for this class."""
+        if cls._registry is None:
+            raise ValueError(f"Cannot get registry for {cls.__name__!r}, not defined!")
+        return cls._REGISTRY.setdefault(cls._registry, {})

--- a/plistsync/services/spotify/__init__.py
+++ b/plistsync/services/spotify/__init__.py
@@ -13,10 +13,7 @@ from .track import SpotifyPlaylistTrack, SpotifyTrack, SpotifyTrackID
 
 
 class SpotifyService(Service):
-    library_cls = SpotifyLibrary
-    track_cls = SpotifyTrack
-    playlist_cls = SpotifyPlaylist
-    playlist_id_cls = SpotifyPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/tidal/__init__.py
+++ b/plistsync/services/tidal/__init__.py
@@ -13,10 +13,7 @@ from .track import TidalPlaylistTrack, TidalTrack, TidalTrackID
 
 
 class TidalService(Service):
-    library_cls = TidalLibrary
-    track_cls = TidalTrack
-    playlist_cls = TidalPlaylist
-    playlist_id_cls = TidalPlaylistID
+    pass
 
 
 __all__ = [

--- a/plistsync/services/traktor/__init__.py
+++ b/plistsync/services/traktor/__init__.py
@@ -13,10 +13,7 @@ from .track import NMLPlaylistTrack, NMLTrack
 
 
 class TraktorService(Service):
-    library_cls = NMLLibrary
-    playlist_cls = NMLPlaylist
-    track_cls = NMLTrack
-    playlist_id_cls = NMLPlaylistID
+    pass
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,9 @@ typed = [
 plistsync = "plistsync.__main__:cli"
 
 [project.entry-points."plistsync.services"]
-# This defines alll actionable services for plistsync.
+# This defines all actionable services for plistsync.
 # Each service is a class that implements the Service interface.
+# See ServiceLoader class for more details
 spotify = "plistsync.services.spotify:SpotifyService"
 tidal = "plistsync.services.tidal:TidalService"
 plex = "plistsync.services.plex:PlexService"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,16 @@ typed = [
 [project.scripts]
 plistsync = "plistsync.__main__:cli"
 
+[project.entry-points."plistsync.services"]
+# This defines alll actionable services for plistsync.
+# Each service is a class that implements the Service interface.
+spotify = "plistsync.services.spotify:SpotifyService"
+tidal = "plistsync.services.tidal:TidalService"
+plex = "plistsync.services.plex:PlexService"
+local = "plistsync.services.local:LocalService"
+traktor = "plistsync.services.traktor:TraktorService"
+beets = "plistsync.services.beets:BeetsService"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/core/mock_playlist.py
+++ b/tests/core/mock_playlist.py
@@ -11,8 +11,7 @@ from plistsync.core.track import OfflineTrack
 
 
 class MockServicePlaylist(
-    OfflinePlaylist,
-    ServicePlaylist[OfflineTrack],
+    OfflinePlaylist, ServicePlaylist[OfflineTrack], service="test"
 ):
     """Mock PlaylistCollection implementation for testing."""
 
@@ -31,8 +30,7 @@ class MockServicePlaylist(
 
 
 class MockMultiRequestServicePlaylist(
-    OfflinePlaylist,
-    MultiRequestServicePlaylist[OfflineTrack],
+    OfflinePlaylist, MultiRequestServicePlaylist[OfflineTrack], service="test"
 ):
     """Mock IncrementalPlaylistCollection implementation for testing."""
 

--- a/tests/core/mock_track.py
+++ b/tests/core/mock_track.py
@@ -2,7 +2,7 @@ from plistsync.core import TrackID
 from plistsync.core.track import Track, TrackInfo
 
 
-class MockTrack(Track):
+class MockTrack(Track, service="test"):
     """Mock Track implementation for testing."""
 
     def __init__(

--- a/tests/core/test_ids.py
+++ b/tests/core/test_ids.py
@@ -141,7 +141,7 @@ class TestTrackIDRepr:
     """The ABC __repr__ is only used by non-dataclass subclasses."""
 
     def test_track_id_repr(self):
-        class _Minimal(TrackID):
+        class _Minimal(TrackID, service="test"):
             @classmethod
             def parse(cls, value: str):
                 return cls()
@@ -153,7 +153,7 @@ class TestTrackIDRepr:
         assert repr(_Minimal()) == "_Minimal(serial='test:123')"
 
     def test_playlist_id_repr(self):
-        class _Minimal(PlaylistID):
+        class _Minimal(PlaylistID, service="test"):
             @classmethod
             def parse(cls, value: str):
                 return cls()

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -9,6 +9,7 @@ from plistsync.core.playlist import (
     Snapshot,
 )
 from plistsync.core.track import OfflineTrack
+from plistsync.services.spotify import SpotifyPlaylistID
 
 from ..core.mock_playlist import MockMultiRequestServicePlaylist, MockServicePlaylist
 from ..core.mock_track import MockTrack
@@ -23,7 +24,7 @@ class TestOfflinePlaylist(TestPlaylistBase):
     def create_playlist(self, name="Name", n_tracks=0):
         return OfflinePlaylist(
             info=PlaylistInfo(name=name, description="description"),
-            id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            id=SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
             tracks=[
                 OfflineTrack(info={"title": f"Track {i}"}, ids={ISRC(str(i))})
                 for i in range(n_tracks)
@@ -56,7 +57,7 @@ class TestMockServicePlaylist(TestServicePlaylistBase):
     def create_playlist(self, name="Name", n_tracks=0):
         return MockServicePlaylist(
             info=PlaylistInfo(name=name, description="description"),
-            id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            id=SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
             tracks=[MockTrack(ids={ISRC(str(i))}) for i in range(n_tracks)],
         )
 
@@ -65,7 +66,7 @@ class TestMockMultiRequestServicePlaylist(TestMultiRequestServicePlaylistBase):
     def create_playlist(self, name="Name", n_tracks=0):
         return MockMultiRequestServicePlaylist(
             info=PlaylistInfo(name=name, description="description"),
-            id_serial="spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            id=SpotifyPlaylistID.parse("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
             tracks=[MockTrack(ids={ISRC(str(i))}) for i in range(n_tracks)],
         )
 

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -1,69 +1,288 @@
 from __future__ import annotations
 
-import sys
-from types import ModuleType
+from abc import ABC, abstractmethod
+from collections.abc import Generator, Iterable
+from typing import Any, Self
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from plistsync.core import Library, Track, TrackInfo
+from plistsync.core.ids import PlaylistID, TrackID
 from plistsync.errors import DependencyError
-from plistsync.services import Service, ServiceRegistry
+from plistsync.services import Service, ServiceLoader
+from plistsync.services.registry import Registry
+
+SERVICE_MODULE = "plistsync.services._test"
+SERVICE_NAME = "_test"
 
 
-class TestDiscovery:
-    """ServiceRegistry discovers Service subclasses and infers names."""
+# ------------------------------ Test fixtures ------------------------------ #
+
+
+class Root(ABC, Registry):
+    """Independent registry root, so tests don't touch core abstractions."""
+
+
+class FakePlaylistID(PlaylistID):
+    __module__ = SERVICE_MODULE
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        return cls()
+
+    @property
+    def serial(self) -> str:
+        return f"{SERVICE_NAME}:playlist:fake"
+
+
+class FakeTrackID(TrackID):
+    __module__ = SERVICE_MODULE
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        return cls()
+
+    @property
+    def serial(self) -> str:
+        return f"{SERVICE_NAME}:track:fake"
+
+
+class FakeTrack(Track):
+    __module__ = SERVICE_MODULE
+
+    @property
+    def info(self) -> TrackInfo:
+        return {}
+
+    @property
+    def ids(self) -> frozenset[TrackID]:
+        return frozenset()
+
+
+class FakeLibrary(Library[Any, Any]):
+    __module__ = SERVICE_MODULE
+
+    @property
+    def playlists(self) -> Iterable[Any]:
+        return []
+
+    def get_playlist(self, *, id: PlaylistID | str | None = None) -> Any | None:
+        return None
+
+    def create_playlist(
+        self,
+        name: str,
+        description: str | None = None,
+        tracks: list[Any] | None = None,
+    ) -> Any:
+        raise NotImplementedError
+
+
+class FakeService(Service):
+    __module__ = SERVICE_MODULE
+
+
+@pytest.fixture(autouse=True)
+def isolate_registry() -> Generator[None, None, None]:
+    """Restore the global registry to its pre-test state.
+
+    Concrete classes register themselves at definition time into the global
+    ``Registry._REGISTRY``. Snapshot and restore it so classes defined inside
+    tests don't leak into other tests.
+    """
+    snapshot = {
+        root: {service: list(classes) for service, classes in bucket.items()}
+        for root, bucket in Registry._REGISTRY.items()
+    }
+    yield
+    Registry._REGISTRY.clear()
+    Registry._REGISTRY.update(snapshot)
+
+
+# ------------------------------- Test Registry ------------------------------ #
+
+
+class TestRegistry:
+    """Registry registers concrete subclasses by service at definition time."""
+
+    def test_concrete_subclasses_register_under_root(self) -> None:
+        class ImplA(Root):
+            __module__ = "plistsync.services._test_a"
+
+        class ImplB(Root):
+            __module__ = "plistsync.services._test_b"
+
+        assert Root.registry() == {"_test_a": [ImplA], "_test_b": [ImplB]}
+
+    def test_multiple_implementations_accumulate_per_service(self) -> None:
+        class ImplA(Root):
+            __module__ = SERVICE_MODULE
+
+        class ImplB(Root):
+            __module__ = SERVICE_MODULE
+
+        assert Root.registry()[SERVICE_NAME] == [ImplA, ImplB]
+
+    def test_explicit_service_kwarg_overrides_module_derivation(self) -> None:
+        class Impl(Root, service="custom"):
+            pass
+
+        assert Root.registry() == {"custom": [Impl]}
+
+    def test_abstract_root_is_not_registered(self) -> None:
+        assert Root.registry() == {}
+        assert Root._registry is Root
+
+    def test_abc_subclass_becomes_new_root(self) -> None:
+        class SubRoot(Root, ABC):
+            pass
+
+        class Impl(SubRoot):
+            __module__ = SERVICE_MODULE
+
+        assert SubRoot._registry is SubRoot
+        assert SubRoot.registry() == {SERVICE_NAME: [Impl]}
+        assert Root.registry() == {}
+
+    def test_subclass_with_abstract_methods_becomes_new_root(self) -> None:
+        class SubRoot(Root):
+            @abstractmethod
+            def abstract_meth(self) -> None: ...
+
+        class Impl(SubRoot):
+            __module__ = SERVICE_MODULE
+
+            def abstract_meth(self) -> None: ...
+
+        assert SubRoot.registry() == {SERVICE_NAME: [Impl]}
+        assert Root.registry() == {}
+
+    def test_service_derivation_fails_outside_services_namespace(self) -> None:
+        with pytest.raises(ValueError, match="Cannot derive service name"):
+
+            class ForeignImpl(Root):
+                pass
+
+    def test_direct_subclass_without_root_fails(self) -> None:
+        with pytest.raises(ValueError, match="does not define a registry key"):
+
+            class Orphan(Registry):
+                pass
+
+    def test_registry_accessor_without_root_fails(self) -> None:
+        with pytest.raises(ValueError, match="not defined"):
+            Registry.registry()
+
+
+# ------------------------------- Test Service ------------------------------- #
+
+
+class TestService:
+    """Service exposes the classes registered for its module-derived name."""
+
+    def test_name_inferred_from_module(self) -> None:
+        assert FakeService().name == SERVICE_NAME
+
+    def test_playlist_ids_returns_registered_classes(self) -> None:
+        assert list(FakeService().playlist_ids()) == [FakePlaylistID]
+
+    def test_track_ids_returns_registered_classes(self) -> None:
+        assert list(FakeService().track_ids()) == [FakeTrackID]
+
+    def test_tracks_returns_registered_classes(self) -> None:
+        assert list(FakeService().tracks()) == [FakeTrack]
+
+    def test_library_returns_registered_class(self) -> None:
+        assert FakeService().library() is FakeLibrary
+
+    def test_library_returns_none_when_unregistered(self) -> None:
+        class LibraryLessService(Service):
+            __module__ = "plistsync.services._test_nolib"
+
+        assert LibraryLessService().library() is None
+
+    def test_unregistered_service_lookups_return_empty(self) -> None:
+        class LonelyService(Service):
+            __module__ = "plistsync.services._test_lonely"
+
+        service = LonelyService()
+        assert service.playlist_ids() == ()
+        assert service.track_ids() == ()
+        assert service.tracks() == ()
+        assert service.library() is None
+
+
+# ----------------------------- Test ServiceLoader ---------------------------- #
+
+
+def _make_entry_point(name: str, loaded: type[Service]) -> MagicMock:
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = loaded
+    return ep
+
+
+class TestServiceLoader:
+    """ServiceLoader discovers services through entry points."""
 
     @pytest.fixture(autouse=True)
-    def clear_cache(self):
-        ServiceRegistry.get.cache_clear()
+    def clear_loader_cache(self) -> Generator[None, None, None]:
+        ServiceLoader.get.__func__.cache_clear()
+        ServiceLoader.all.__func__.cache_clear()
         yield
-        ServiceRegistry.get.cache_clear()
+        ServiceLoader.get.__func__.cache_clear()
+        ServiceLoader.all.__func__.cache_clear()
 
-    def test_get_service_returns_instance_with_correct_name(self):
-        """Discovered service has name matching its module."""
-        fake_module = ModuleType("plistsync.services._test_fake")
+    def test_get_returns_service_instance(self) -> None:
+        ep = _make_entry_point(SERVICE_NAME, FakeService)
+        with patch("plistsync.services.entry_points", return_value=[ep]):
+            service = ServiceLoader.get(SERVICE_NAME)
 
-        class FakeService(Service):
-            track_cls = int  # type: ignore[assignment]
+        assert isinstance(service, FakeService)
+        assert service.name == SERVICE_NAME
+        ep.load.assert_called_once()
 
-        FakeService.__module__ = "plistsync.services._test_fake"
-        fake_module.FakeService = FakeService  # type: ignore[assignment]
+    def test_get_returns_none_for_unknown_service(self) -> None:
+        with patch("plistsync.services.entry_points", return_value=[]):
+            assert ServiceLoader.get("_nonexistent") is None
 
-        with patch.object(
-            sys, "modules", {**sys.modules, fake_module.__name__: fake_module}
-        ):
-            with patch("importlib.import_module", return_value=fake_module):
-                service = ServiceRegistry.get("_test_fake")
+    def test_get_returns_none_when_dependencies_missing(self) -> None:
+        ep = _make_entry_point("_test_broken", FakeService)
+        ep.load.side_effect = DependencyError("_test_broken", ["missing_pkg"])
+        with patch("plistsync.services.entry_points", return_value=[ep]):
+            assert ServiceLoader.get("_test_broken") is None
 
-        assert service is not None
-        assert service.name == "_test_fake"
+    def test_get_returns_none_when_module_missing(self) -> None:
+        ep = _make_entry_point("_test_broken", FakeService)
+        ep.load.side_effect = ModuleNotFoundError("No module named 'missing_pkg'")
+        with patch("plistsync.services.entry_points", return_value=[ep]):
+            assert ServiceLoader.get("_test_broken") is None
 
-    def test_get_service_returns_none_for_missing_dependency(self):
-        with patch(
-            "importlib.import_module",
-            side_effect=DependencyError("svc", ["pkg"]),
-        ):
-            assert ServiceRegistry.get("svc") is None
+    def test_all_returns_mapping_of_available_services(self) -> None:
+        class OtherService(Service):
+            __module__ = "plistsync.services._test_other"
 
-    def test_get_service_returns_none_when_no_service_subclass(self):
-        empty = ModuleType("plistsync.services._test_empty")
-        with patch.object(sys, "modules", {**sys.modules, empty.__name__: empty}):
-            with patch("importlib.import_module", return_value=empty):
-                assert ServiceRegistry.get("_test_empty") is None
+        eps = [
+            _make_entry_point(SERVICE_NAME, FakeService),
+            _make_entry_point("_test_other", OtherService),
+        ]
+        with patch("plistsync.services.entry_points", return_value=eps):
+            result = ServiceLoader.all()
 
-    def test_dict_keys_are_module_names(self):
-        result = ServiceRegistry.dict()
-        for name in result:
-            assert result[name].name == name
+        assert set(result) == {SERVICE_NAME, "_test_other"}
+        assert isinstance(result[SERVICE_NAME], FakeService)
+        assert isinstance(result["_test_other"], OtherService)
+        for name, service in result.items():
+            assert service.name == name
 
-    def test_dict_filters_broken_modules(self):
-        with patch(
-            "pkgutil.iter_modules",
-            return_value=[MagicMock(name="_test_broken")],
-        ):
-            with patch(
-                "importlib.import_module",
-                side_effect=DependencyError("_test_broken", ["pkg"]),
-            ):
-                result = ServiceRegistry.dict()
+    def test_all_skips_services_with_missing_dependencies(self) -> None:
+        good = _make_entry_point(SERVICE_NAME, FakeService)
+        broken = _make_entry_point("_test_broken", FakeService)
+        broken.load.side_effect = DependencyError("_test_broken", ["missing_pkg"])
+
+        with patch("plistsync.services.entry_points", return_value=[good, broken]):
+            result = ServiceLoader.all()
+
+        assert SERVICE_NAME in result
         assert "_test_broken" not in result


### PR DESCRIPTION
## Summary

Replaces the import-based `ServiceRegistry` with a generic `Registry` base
class: concrete implementations of `Track`, `Library`, `TrackID`, and
`PlaylistID` auto-register at class-definition time, keyed by service name.
Services are discovered lazily through the `plistsync.services` entry-point
group via `ServiceLoader`, without importing all service modules.

`Service` now resolves its classes through the registry (`library()`,
`tracks()`, `track_ids()`, `playlist_ids()`); the redundant `*_cls`
attributes are removed. `OfflinePlaylist` takes a typed `PlaylistID`
instead of an `id_serial` string.

## Breaking changes

- `ServiceRegistry` → `ServiceLoader.get(name)` / `ServiceLoader.all()`
- `Service.*_cls` attributes → registry-backed accessors
- `OfflinePlaylist(id_serial=...)` → `OfflinePlaylist(id=<PlaylistID>)`
- Registry subclasses outside `plistsync.services.*` need an explicit
  `service="name"` class kwarg


## What is registered?

```
{
    plistsync.core.ids.TrackID: {
        "core": [plistsync.core.ids.ISRC, plistsync.core.ids.FilePath],
        "beets": [plistsync.services.beets.track.BeetsTrackID],
        "plex": [plistsync.services.plex.track.PlexTrackID],
        "spotify": [plistsync.services.spotify.track.SpotifyTrackID],
        "tidal": [plistsync.services.tidal.track.TidalTrackID],
    },
    plistsync.core.track.Track: {
        "core": [plistsync.core.track.OfflineTrack],
        "beets": [plistsync.services.beets.track.BeetsTrack],
        "local": [plistsync.services.local.track.LocalTrack],
        "plex": [plistsync.services.plex.track.PlexTrack],
        "spotify": [
            plistsync.services.spotify.track.SpotifyTrack,
            plistsync.services.spotify.track.SpotifyPlaylistTrack,
        ],
        "tidal": [
            plistsync.services.tidal.track.TidalTrack,
            plistsync.services.tidal.track.TidalPlaylistTrack,
        ],
    },
    plistsync.core.playlist.Playlist: {
        "core": [plistsync.core.playlist.OfflinePlaylist]
    },
    plistsync.services.Service: {
        "beets": [plistsync.services.beets.BeetsService],
        "local": [plistsync.services.local.LocalService],
        "plex": [plistsync.services.plex.PlexService],
        "spotify": [plistsync.services.spotify.SpotifyService],
        "tidal": [plistsync.services.tidal.TidalService],
    },
    plistsync.core.ids.PlaylistID: {
        "plex": [plistsync.services.plex.playlist.PlexPlaylistID],
        "spotify": [plistsync.services.spotify.playlist.SpotifyPlaylistID],
        "tidal": [plistsync.services.tidal.playlist.TidalPlaylistID],
    },
    plistsync.core.playlist.MultiRequestServicePlaylist: {
        "plex": [plistsync.services.plex.playlist.PlexPlaylist],
        "spotify": [plistsync.services.spotify.playlist.SpotifyPlaylist],
        "tidal": [plistsync.services.tidal.playlist.TidalPlaylist],
    },
    plistsync.core.collection.Library: {
        "plex": [plistsync.services.plex.library.PlexLibrary],
        "spotify": [plistsync.services.spotify.library.SpotifyLibrary],
        "tidal": [plistsync.services.tidal.library.TidalLibrary],
    },
}
```

Im not entierly sure if we want `MultiRequestServicePlaylist` and `Playlist` as seperate registry keys

## Tests

Rewrote `tests/services/test_registry.py` covering `Registry`, `Service`
accessors, and `ServiceLoader` discovery.