### PR TITLE
 Added serialization layer to `SyncedPlaylist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This improves type safety, clarity, and extensibility for playlist identificatio
   - Phased `sync()` pipeline: `refresh()` pulls the current state from each service, `merge()` reconciles external additions/removals/reorders into the internal collection, `enrich()` cross-links tracks between services and backfills missing identifiers (e.g. ISRCs), and `push()` writes the resolved state back to every linked playlist.
   - Track association is availability-aware: tracks that cannot be resolved on a given service are skipped for that service instead of being dropped from the internal collection.
   - Added `SyncedPlaylistID`, a UUID-based playlist identifier for synced playlists.
+  - Added serialization for SyncedPlaylists, `save_to` and `load_from` methods (#104)
 
 ### Fixed
 

--- a/plistsync/core/crdt/serialize.py
+++ b/plistsync/core/crdt/serialize.py
@@ -1,25 +1,13 @@
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import Generic, Literal, Protocol, TypedDict, TypeVar, cast
+from typing import Generic, Literal, TypedDict, cast
+
+from plistsync.core.crdt import RegisterOp
+from plistsync.core.crdt.lww import LWWRegister
+from plistsync.utils.serializer import DummySerializer, S, Serializer, T
 
 from .fugue import DeleteOp, Fugue, InsertOp, InsertPos
 from .graph import NodeID, Side
-
-T = TypeVar("T")
-S = TypeVar("S")
-
-
-class Serializer(Protocol, Generic[T, S]):
-    @abstractmethod
-    def dump(self, value: T) -> S:
-        """Serialize a Fugue instance to a string."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def load(self, data: S) -> T:
-        """Deserialize a Fugue instance from a string."""
-        raise NotImplementedError
 
 
 class NodeIDState(TypedDict):
@@ -33,6 +21,22 @@ class NodeIDState(TypedDict):
 
     counter: int
     """Counter value for the node ID."""
+
+
+class NodeSerializer(Serializer[NodeID, NodeIDState]):
+    """Serializer for Fugue node IDs."""
+
+    def dump(self, value: NodeID) -> NodeIDState:
+        return NodeIDState(
+            replica_id=value.replica_id,
+            counter=value.counter,
+        )
+
+    def load(self, data: NodeIDState) -> NodeID:
+        return NodeID(
+            replica_id=data["replica_id"],
+            counter=data["counter"],
+        )
 
 
 class OpStateInsert(TypedDict):
@@ -91,9 +95,11 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
     """Serializer for Fugue instances, using a provided serializer for the values."""
 
     serializer: Serializer[T, S]
+    node_serializer: NodeSerializer
 
     def __init__(self, serializer: Serializer[T, S]) -> None:
         self.serializer = serializer
+        self.node_serializer = NodeSerializer()
 
     def dump(self, value: Fugue[T]) -> FugueState[S]:
         values: list[S] = []
@@ -104,10 +110,10 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
                 values.append(self.serializer.dump(op.value))
                 ops.append(
                     OpStateInsert(
-                        node_id=self.dump_node_id(op.pos.id),
-                        parent_id=self.dump_node_id(op.pos.parent_id),
+                        node_id=self.node_serializer.dump(op.pos.id),
+                        parent_id=self.node_serializer.dump(op.pos.parent_id),
                         side=self.dump_side(op.pos.side),
-                        right_of_id=self.dump_node_id(op.pos.right_of_id)
+                        right_of_id=self.node_serializer.dump(op.pos.right_of_id)
                         if op.pos.right_of_id
                         else None,
                         value_ref=len(values) - 1,
@@ -116,7 +122,7 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
             else:
                 ops.append(
                     OpStateDelete(
-                        node_id=self.dump_node_id(op.node_id),
+                        node_id=self.node_serializer.dump(op.node_id),
                     )
                 )
 
@@ -139,10 +145,10 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
                 fugue.apply(
                     InsertOp(
                         pos=InsertPos(
-                            id=self.load_node_id(ins["node_id"]),
-                            parent_id=self.load_node_id(ins["parent_id"]),
+                            id=self.node_serializer.load(ins["node_id"]),
+                            parent_id=self.node_serializer.load(ins["parent_id"]),
                             side=self.load_side(ins["side"]),
-                            right_of_id=self.load_node_id(ins["right_of_id"])
+                            right_of_id=self.node_serializer.load(ins["right_of_id"])
                             if ins["right_of_id"]
                             else None,
                         ),
@@ -152,25 +158,11 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
             else:  # delete
                 fugue.apply(
                     DeleteOp(
-                        node_id=self.load_node_id(op["node_id"]),
+                        node_id=self.node_serializer.load(op["node_id"]),
                     )
                 )
 
         return fugue
-
-    @staticmethod
-    def dump_node_id(node_id: NodeID) -> NodeIDState:
-        return NodeIDState(
-            replica_id=node_id.replica_id,
-            counter=node_id.counter,
-        )
-
-    @staticmethod
-    def load_node_id(node_id: NodeIDState) -> NodeID:
-        return NodeID(
-            replica_id=node_id["replica_id"],
-            counter=node_id["counter"],
-        )
 
     @staticmethod
     def dump_side(side: Side) -> Literal[0, 1]:
@@ -179,3 +171,82 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
     @staticmethod
     def load_side(side: Literal[0, 1]) -> Side:
         return Side.LEFT if side == 0 else Side.RIGHT
+
+
+class RegisterOpState(TypedDict, Generic[S]):
+    """Snapshot format for a Fugue operation.
+
+    Used for serialization and deserialization.
+    """
+
+    node_id: NodeIDState
+    """Simplified node ID for the operation. We reuse the NodeIDState
+    format for simplicity."""
+
+    value: S
+    """Serialized value associated with the operation."""
+
+    key: str
+    """Key associated with the operation. In a register, this is typically the field
+    name being updated."""
+
+
+class LWWRegisterState(TypedDict, Generic[S]):
+    """Serialized form of a :class:`LWWRegister`."""
+
+    version: int
+    """Version of the serialized state. Used for compatibility checks."""
+
+    counter: int
+    """Unique identifier for the replica that produced this state."""
+
+    replica_id: int
+    """Unique identifier for the replica that produced this state."""
+
+    ops: list[RegisterOpState[S]]
+    """List of operations (insertions) in the LWW register."""
+
+
+class LWWSerializer(Serializer[LWWRegister, LWWRegisterState[S]], Generic[T, S]):
+    """Serializer for LWW values."""
+
+    serializer: Serializer[T, S]
+    node_serializer: NodeSerializer
+
+    def __init__(self, serializer: Serializer[T, S] | None = None) -> None:
+        self.serializer = serializer or DummySerializer()
+        self.node_serializer = NodeSerializer()
+
+    def dump(self, value: LWWRegister) -> LWWRegisterState[S]:
+        ops: list[RegisterOpState[S]] = []
+
+        for op in value._ops:
+            ops.append(
+                RegisterOpState(
+                    node_id=self.node_serializer.dump(op.version),
+                    value=self.serializer.dump(op.value),
+                    key=op.key,
+                )
+            )
+
+        return LWWRegisterState(
+            version=1,
+            counter=value._counter,
+            replica_id=value.replica_id,
+            ops=ops,
+        )
+
+    def load(self, data: LWWRegisterState[S]) -> LWWRegister:
+        register = LWWRegister(replica_id=data["replica_id"])
+        register._counter = data["counter"]
+
+        for op in data["ops"]:
+            register.apply(
+                RegisterOp(
+                    key="value",  # Assuming a single field for simplicity
+                    value=self.serializer.load(op["value"]),
+                    version=self.node_serializer.load(op["node_id"]),
+                )
+            )
+
+        return register

--- a/plistsync/core/crdt/serialize.py
+++ b/plistsync/core/crdt/serialize.py
@@ -34,8 +34,8 @@ class NodeSerializer(Serializer[NodeID, NodeIDState]):
 
     def load(self, data: NodeIDState) -> NodeID:
         return NodeID(
-            replica_id=data["replica_id"],
-            counter=data["counter"],
+            replica_id=int(data["replica_id"]),
+            counter=int(data["counter"]),
         )
 
 
@@ -136,7 +136,9 @@ class FugueSerializer(Serializer[Fugue[T], FugueState[S]], Generic[T, S]):
 
     def load(self, data: FugueState[S]) -> Fugue[T]:
         fugue = Fugue[T](replica_id=data["replica_id"])
-        fugue._counters = dict(data["counters"])
+        fugue._counters = {
+            int(rid): counter for rid, counter in data["counters"].items()
+        }
         values = data["values"]
         for op in data["ops"]:
             if "value_ref" in op:  # insert
@@ -243,7 +245,7 @@ class LWWSerializer(Serializer[LWWRegister, LWWRegisterState[S]], Generic[T, S])
         for op in data["ops"]:
             register.apply(
                 RegisterOp(
-                    key="value",  # Assuming a single field for simplicity
+                    key=op["key"],
                     value=self.serializer.load(op["value"]),
                     version=self.node_serializer.load(op["node_id"]),
                 )

--- a/plistsync/core/ids.py
+++ b/plistsync/core/ids.py
@@ -18,17 +18,13 @@ class SerialID(ABC):
     @classmethod
     @abstractmethod
     def parse(cls, value: str) -> Self:
-        """Parse from user input (URL, URI, or raw id)."""
+        """Parse from user input (URL, URI, serial, or raw id)."""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def serial(self) -> str:
-        """
-        Plistsync's internal string-representation of service specific playlist ID.
-
-        By convention it should look like `service_name:your_custom:format` e.g.
-        `spotify:playlist:actual_id`. This is not enforced but recommended.
+        """Canonical namespaced string representation (``<namespace>:<payload>``).
 
         By convention, to get the _canonical_ representation that the service API
         understands, you should define `__str__` or `__int__` methods to get the

--- a/plistsync/core/sync/__init__.py
+++ b/plistsync/core/sync/__init__.py
@@ -1,9 +1,6 @@
 """Synchronisation primitives for cross-service playlist management."""
 
-from plistsync.core.sync.playlist import (
-    SyncedPlaylist,
-    SyncedPlaylistID,
-)
+from plistsync.core.sync.playlist import SyncedPlaylist, SyncedPlaylistID
 
 __all__ = [
     "SyncedPlaylist",

--- a/plistsync/core/sync/playlist.py
+++ b/plistsync/core/sync/playlist.py
@@ -19,6 +19,7 @@ from plistsync.logger import log
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
+    from pathlib import Path
 
     from plistsync.core import Track
     from plistsync.core.crdt import DeleteOp as CRDTDeleteOp
@@ -361,4 +362,31 @@ class SyncedPlaylist(Playlist[OfflineTrack], service="core"):
                     new_tracks.append(match.best_match)
 
         with playlist.edit():
+            playlist.name = self.name
+            playlist.description = self.description
             playlist.tracks = new_tracks
+
+    def save_to(self, path: Path | str) -> None:
+        """Serialize the synced playlist to a JSON-serializable object."""
+        import json
+
+        from .serialize import SyncedPlaylistSerializer
+
+        serializer = SyncedPlaylistSerializer()
+        serializable = serializer.dump(self)
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(serializable, f, indent=4)
+
+    @classmethod
+    def load_from(cls, path: Path | str) -> SyncedPlaylist:
+        """Load a synced playlist from a JSON-serializable object."""
+        import json
+
+        from .serialize import SyncedPlaylistSerializer
+
+        with open(path, encoding="utf-8") as f:
+            serializable = json.load(f)
+
+        serializer = SyncedPlaylistSerializer()
+        return serializer.load(serializable)

--- a/plistsync/core/sync/serialize.py
+++ b/plistsync/core/sync/serialize.py
@@ -1,0 +1,154 @@
+"""Serialization layer for :class:`SyncedPlaylist`.
+
+Composes with :class:`FugueSerializer` for the internal CRDT and provides
+round-trip dump/load via plain TypedDict states.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic, TypedDict, TypeVar
+
+from plistsync.core import PlaylistID, TrackID
+from plistsync.core.crdt.serialize import (
+    FugueSerializer,
+    LWWSerializer,
+    Serializer,
+)
+from plistsync.core.sync.playlist import (
+    SyncedPlaylist,
+    SyncedPlaylistID,
+    _TrackLink,
+)
+from plistsync.core.track import OfflineTrack
+from plistsync.services import ServiceLoader
+
+if TYPE_CHECKING:
+    from plistsync.core.crdt.serialize import (
+        FugueState,
+        LWWRegisterState,
+    )
+    from plistsync.core.playlist import PlaylistInfo
+
+S = TypeVar("S")  # serialized track format (e.g. dict or str)
+
+
+class SyncedPlaylistState(TypedDict, Generic[S]):
+    """Serialized form of a :class:`SyncedPlaylist`."""
+
+    version: int
+    """Version of the serialized state. Used for compatibility checks."""
+
+    id: str
+    """Unique identifier for the synced playlist."""
+
+    info: LWWRegisterState[PlaylistInfo]
+    """Serialized LWW register for the playlist's info."""
+
+    fugue: FugueState[S]
+    """Serialized Fugue state for the playlist's track list."""
+
+    linked_playlists: dict[int, str]
+    """Mapping of replica IDs to linked playlist serials."""
+
+
+class TrackLinkSerializer(Serializer[_TrackLink, dict]):
+    """Serializer for :class:`_TrackLink` instances."""
+
+    def dump(self, value: _TrackLink) -> dict:
+        return {
+            "track": {
+                "ids": [id.serial for id in value.track.ids],
+                "info": value.track.info,
+            },
+            "in_playlists": [pid.serial for pid in value.playlists],
+        }
+
+    def load(self, data: dict) -> _TrackLink:
+        track_ids: list[TrackID] = []
+        for id in data["track"]["ids"]:
+            if not (track_id := TrackID.from_serial(id)):
+                raise ValueError(f"Invalid track ID serial {id!r}")
+            track_ids.append(track_id)
+
+        playlist_ids: list[PlaylistID] = []
+        for pid in data["in_playlists"]:
+            if not (playlist_id := PlaylistID.from_serial(pid)):
+                raise ValueError(f"Invalid playlist ID serial {pid!r}")
+            playlist_ids.append(playlist_id)
+
+        return _TrackLink(
+            track=OfflineTrack(
+                ids=track_ids,
+                info=data["track"]["info"],
+            ),
+            playlists=set(playlist_ids),
+        )
+
+
+class SyncedPlaylistSerializer(Serializer[SyncedPlaylist, SyncedPlaylistState[dict]]):
+    """Round-trip serializer for :class:`SyncedPlaylist`."""
+
+    def __init__(
+        self,
+    ) -> None:
+        self._fugue_ser: FugueSerializer[_TrackLink, dict] = FugueSerializer(
+            TrackLinkSerializer()
+        )
+        self._lww_ser: LWWSerializer[PlaylistInfo, PlaylistInfo] = LWWSerializer()
+
+    def dump(self, value: SyncedPlaylist) -> SyncedPlaylistState[dict]:
+        linked_playlists: dict[int, str] = {
+            rid: pid.id.serial for rid, pid in value._linked_playlists.items()
+        }
+
+        return SyncedPlaylistState(
+            version=1,
+            id=value.id.serial,
+            info=self._lww_ser.dump(value._info),
+            fugue=self._fugue_ser.dump(value._fugue),
+            linked_playlists=linked_playlists,
+        )
+
+    def load(
+        self,
+        data: SyncedPlaylistState[dict],
+    ) -> SyncedPlaylist:
+        sp = SyncedPlaylist(
+            name="",
+            description="",
+        )
+
+        # Override auto-generated ID with the persisted one.
+        sp._id = SyncedPlaylistID.parse(data["id"])
+        sp._fugue = self._fugue_ser.load(data["fugue"])
+        sp._info = self._lww_ser.load(data["info"])
+
+        for rid_str, pid_serial in data["linked_playlists"].items():
+            service_pl_id = PlaylistID.from_serial(pid_serial)
+            if service_pl_id is None:
+                raise ValueError(
+                    f"Invalid linked playlist serial {pid_serial!r}"
+                    f" for replica {rid_str!r}"
+                )
+
+            if not (service := ServiceLoader.get(service_pl_id.service())):
+                raise ValueError(
+                    f"Service {service_pl_id.service()!r} not available"
+                    f" maybe the service is not installed or configured?"
+                )
+
+            if not (library_cls := service.library()):
+                raise ValueError(
+                    f"Service {service_pl_id.service()!r} has no library"
+                    f" maybe the service is not installed or configured?"
+                )
+
+            # TODO:
+            # Currently libraries are a bit of annoying as in theory
+            # a library can be created with different config options
+            # we assume that the config is the same as when the playlist
+            # was serialized. This may or may not be wrong...
+            playlist = library_cls().get_playlist_or_raise(id=service_pl_id)
+            sp._linked_playlists[int(rid_str)] = playlist
+
+        return sp

--- a/plistsync/utils/serializer.py
+++ b/plistsync/utils/serializer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Generic, Protocol, TypeVar, cast
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+class Serializer(Protocol, Generic[T, S]):
+    @abstractmethod
+    def dump(self, value: T) -> S:
+        """Serialize a Fugue instance to a string."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def load(self, data: S) -> T:
+        """Deserialize a Fugue instance from a string."""
+        raise NotImplementedError
+
+
+class DummySerializer(Serializer[T, S]):
+    """A dummy serializer that does nothing."""
+
+    def dump(self, value: T) -> S:
+        return cast(S, value)
+
+    def load(self, data: S) -> T:
+        return cast(T, data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ ignore = [
     "D10",
     "D202",
     "PTH123", # Do not require Path.open
+    "TC006", # no need to quote 'cast's since we use 'from __future__ import annotations'
 ]
 fixable = ["ALL"]
 

--- a/tests/core/crdt/test_serialize.py
+++ b/tests/core/crdt/test_serialize.py
@@ -13,6 +13,7 @@ from plistsync.core.crdt.serialize import (
     FugueSerializer,
     FugueState,
     NodeIDState,
+    NodeSerializer,
     OpStateDelete,
     OpStateInsert,
     Serializer,
@@ -65,12 +66,12 @@ class TestNodeID:
     )
     def test_roundtrip(self, replica_id: int, counter: int) -> None:
         nid = _nid(replica_id, counter)
-        state = FugueSerializer.dump_node_id(nid)
+        state = NodeSerializer().dump(nid)
         assert state == {"replica_id": replica_id, "counter": counter}
-        assert FugueSerializer.load_node_id(state) == nid
+        assert NodeSerializer().load(state) == nid
 
     def test_dump_keys(self) -> None:
-        assert set(FugueSerializer.dump_node_id(_nid())) == {"replica_id", "counter"}
+        assert set(NodeSerializer().dump(_nid())) == {"replica_id", "counter"}
 
 
 class TestSide:

--- a/tests/core/crdt/test_serialize.py
+++ b/tests/core/crdt/test_serialize.py
@@ -3,49 +3,148 @@
 from __future__ import annotations
 
 import json
-from typing import Literal, cast
+from typing import Any, Literal, cast, TYPE_CHECKING
 
 import pytest
 
 from plistsync.core.crdt.fugue import Fugue
 from plistsync.core.crdt.graph import NodeID, Side
+from plistsync.core.crdt.lww import LWWRegister
 from plistsync.core.crdt.serialize import (
     FugueSerializer,
     FugueState,
+    LWWSerializer,
     NodeIDState,
     NodeSerializer,
     OpStateDelete,
     OpStateInsert,
-    Serializer,
 )
+from plistsync.utils.serializer import DummySerializer
+
+if TYPE_CHECKING:
+    from plistsync.core.crdt.serialize import (
+        LWWRegisterState,
+    )
 
 
-class IdSerializer(Serializer[str, str]):
-    def dump(self, value: str) -> str:
-        return value
+class TestNodeID:
+    @pytest.mark.parametrize(
+        ("replica_id", "counter"),
+        [(0, 0), (1, 42), (255, 65535)],
+    )
+    def test_roundtrip(self, replica_id: int, counter: int) -> None:
+        nid = NodeID(replica_id, counter)
 
-    def load(self, data: str) -> str:
-        return data
+        # Serialize
+        state = NodeSerializer().dump(nid)
+        assert state == {"replica_id": replica_id, "counter": counter}
 
+        # Deserialize
+        n_nid = NodeSerializer().load(json.loads(json.dumps(state)))
 
-class JsonSerializer(Serializer[int, str]):
-    def dump(self, value: int) -> str:
-        return json.dumps(value)
-
-    def load(self, data: str) -> int:
-        return json.loads(data)
-
-
-def _nid(replica_id: int = 0, counter: int = 0) -> NodeID:
-    return NodeID(replica_id, counter)
-
-
-def _nids(replica_id: int = 0, counter: int = 0) -> NodeIDState:
-    return NodeIDState(replica_id=replica_id, counter=counter)
+        # Assert
+        assert isinstance(n_nid, NodeID)
+        assert isinstance(n_nid.replica_id, int)
+        assert isinstance(n_nid.counter, int)
+        assert n_nid == nid
 
 
-def _root() -> NodeIDState:
-    return _nids(-1, -1)
+class TestSide:
+    @pytest.mark.parametrize("side", [Side.LEFT, Side.RIGHT])
+    def test_roundtrip(self, side: Side) -> None:
+        # Serialize
+        state = FugueSerializer.dump_side(side)
+        assert state in (0, 1)
+
+        # Deserialize
+        n_side = FugueSerializer.load_side(json.loads(json.dumps(state)))
+
+        # Assert
+        assert isinstance(n_side, Side)
+        assert n_side == side
+
+
+class TestFugue:
+    @pytest.mark.parametrize(
+        "values",
+        [[], ["a"], ["x", "y", "z"]],
+    )
+    def test_roundtrip(self, s: FugueSerializer[str, str], values: list[str]) -> None:
+        fu = _fugue(*values)
+
+        # Serialize
+        state = s.dump(fu)
+        assert state["values"] == values
+
+        # Deserialize
+        n_fu = s.load(json.loads(json.dumps(state)))
+
+        # Assert
+        assert isinstance(n_fu, Fugue)
+        assert list(n_fu) == values
+        assert n_fu.replica_id == fu.replica_id
+        assert n_fu._counters == fu._counters
+        assert all(isinstance(k, int) for k in n_fu._counters)
+
+    def test_roundtrip_with_delete(self, s: FugueSerializer[str, str]) -> None:
+        fu = _fugue("keep", "drop")
+        fu.delete(1)
+
+        # Serialize
+        state = s.dump(fu)
+        assert state["values"] == ["keep", "drop"]
+
+        # Deserialize
+        n_fu = s.load(json.loads(json.dumps(state)))
+
+        # Assert
+        assert isinstance(n_fu, Fugue)
+        assert list(n_fu) == ["keep"]
+
+
+class TestLWWRegister:
+    @pytest.mark.parametrize(
+        "assignments",
+        [
+            [],
+            [("name", "Mix")],
+            [("name", "Mix"), ("description", "Desc")],
+            [("name", "A"), ("name", "B")],  # last write wins
+        ],
+    )
+    def test_roundtrip(self, assignments: list[tuple[str, str]]) -> None:
+        reg = LWWRegister(replica_id=0)
+        for key, value in assignments:
+            reg.assign(key, value)
+
+        # Serialize
+        state: LWWRegisterState[Any] = LWWSerializer().dump(reg)
+        assert state["version"] == 1
+        assert set(state) == {"version", "counter", "replica_id", "ops"}
+        assert len(state["ops"]) == len(assignments)
+        for op in state["ops"]:
+            assert set(op) == {"node_id", "value", "key"}
+
+        # Deserialize
+        n_reg = LWWSerializer().load(json.loads(json.dumps(state)))
+
+        # Assert
+        assert isinstance(n_reg, LWWRegister)
+        assert dict(n_reg) == dict(reg)
+        assert n_reg.replica_id == reg.replica_id
+        assert n_reg._counter == reg._counter
+
+    def test_roundtrip_preserves_history(self) -> None:
+        reg = LWWRegister(replica_id=1)
+        reg.assign("name", "A")
+        reg.assign("name", "B")
+
+        # Serialize / Deserialize
+        n_reg = LWWSerializer().load(json.loads(json.dumps(LWWSerializer().dump(reg))))
+
+        # Assert
+        assert n_reg["name"] == "B"
+        assert [op.value for op in n_reg.history("name")] == ["A", "B"]
 
 
 def _fugue(*values: str, replica_id: int = 0) -> Fugue[str]:
@@ -55,70 +154,23 @@ def _fugue(*values: str, replica_id: int = 0) -> Fugue[str]:
     return fu
 
 
+def _nids(replica_id: int = 0, counter: int = 0) -> NodeIDState:
+    return NodeIDState(replica_id=replica_id, counter=counter)
+
+
 def _roundtrip(s: FugueSerializer[str, str], fu: Fugue[str]) -> Fugue[str]:
     return s.load(s.dump(fu))
 
 
-class TestNodeID:
-    @pytest.mark.parametrize(
-        ("replica_id", "counter"),
-        [(0, 0), (1, 42), (255, 65535)],
-    )
-    def test_roundtrip(self, replica_id: int, counter: int) -> None:
-        nid = _nid(replica_id, counter)
-        state = NodeSerializer().dump(nid)
-        assert state == {"replica_id": replica_id, "counter": counter}
-        assert NodeSerializer().load(state) == nid
-
-    def test_dump_keys(self) -> None:
-        assert set(NodeSerializer().dump(_nid())) == {"replica_id", "counter"}
-
-
-class TestSide:
-    @pytest.mark.parametrize(
-        ("side", "num"),
-        [(Side.LEFT, 0), (Side.RIGHT, 1)],
-    )
-    def test_dump(self, side: Side, num: int) -> None:
-        assert FugueSerializer.dump_side(side) == num
-
-    @pytest.mark.parametrize(
-        ("num", "side"),
-        [(0, Side.LEFT), (1, Side.RIGHT)],
-    )
-    def test_load(self, num: Literal[0, 1], side: Side) -> None:
-        assert FugueSerializer.load_side(num) == side
-
-    @pytest.mark.parametrize("side", [Side.LEFT, Side.RIGHT])
-    def test_roundtrip(self, side: Side) -> None:
-        assert FugueSerializer.load_side(FugueSerializer.dump_side(side)) == side
-
-
 @pytest.fixture
 def s() -> FugueSerializer[str, str]:
-    return FugueSerializer(IdSerializer())
+    return FugueSerializer(DummySerializer())
 
 
 class TestDump:
-    @pytest.mark.parametrize(
-        ("fu", "ops", "values"),
-        [
-            (_fugue(), 0, []),
-            (_fugue("a"), 1, ["a"]),
-            (_fugue("a", "b", "c"), 3, ["a", "b", "c"]),
-        ],
-    )
-    def test_shape(
-        self,
-        s: FugueSerializer[str, str],
-        fu: Fugue[str],
-        ops: int,
-        values: list[str],
-    ) -> None:
-        state = s.dump(fu)
+    def test_shape(self, s: FugueSerializer[str, str]) -> None:
+        state = s.dump(_fugue("a"))
         assert state["version"] == 1
-        assert len(state["ops"]) == ops
-        assert state["values"] == values
         assert set(state) == {"version", "replica_id", "counters", "ops", "values"}
 
     def test_delete_op(self, s: FugueSerializer[str, str]) -> None:
@@ -129,7 +181,6 @@ class TestDump:
         assert "value_ref" in state["ops"][0]
         assert "value_ref" in state["ops"][1]
         assert set(state["ops"][2]) == {"node_id"}
-        assert state["values"] == ["keep", "drop"]
 
     def test_insert_op_shape(self, s: FugueSerializer[str, str]) -> None:
         fu = _fugue("x")
@@ -154,7 +205,12 @@ class TestDump:
     ) -> None:
         fu = _fugue("a", "b", replica_id=replica_id)
         state = s.dump(fu)
+
         assert state["replica_id"] == replica_id
+        assert isinstance(state["counters"], dict)
+        for rid, counter in state["counters"].items():
+            assert isinstance(rid, int)
+            assert isinstance(counter, int)
         assert state["counters"] == expected_counters
 
     def test_multi_replica_counters(self, s: FugueSerializer[str, str]) -> None:
@@ -191,6 +247,10 @@ def _state(
         ops=list(ops),
         values=values or [],
     )
+
+
+def _root() -> NodeIDState:
+    return _nids(-1, -1)
 
 
 def _insert(
@@ -332,25 +392,6 @@ class TestRoundtrip:
     def test_delete_only_state_is_valid(self, s: FugueSerializer[str, str]) -> None:
         fu = s.load(_state(_delete(_nids(1, 0))))
         assert list(fu) == []
-
-
-class TestCustomValues:
-    def test_roundtrip_with_json(self) -> None:
-        s = FugueSerializer(JsonSerializer())
-        fu: Fugue[int] = Fugue()
-        fu.insert(0, 42)
-        fu.insert(1, -7)
-        state = s.dump(fu)
-        assert state["values"] == ["42", "-7"]
-        assert list(s.load(state)) == [42, -7]
-
-    def test_not_called_for_deletes(self) -> None:
-        s = FugueSerializer(JsonSerializer())
-        fu: Fugue[int] = Fugue()
-        fu.insert(0, 1)
-        fu.insert(1, 2)
-        fu.delete(0)
-        assert len(s.dump(fu)["values"]) == 2  # only inserts produce values
 
 
 class TestMultiReplica:

--- a/tests/core/sync/test_playlist.py
+++ b/tests/core/sync/test_playlist.py
@@ -236,7 +236,7 @@ class TestMerge:
 class TestMergeInfo:
     """Merging of playlist metadata (name/description) from linked playlists."""
 
-    def test_service_name_is_merged(self):
+    def test_service_name_is_not_merged(self):
         playlist = SyncedPlaylist("internal")
         service = make_playlist(name="service")
         playlist.register(service)
@@ -244,7 +244,7 @@ class TestMergeInfo:
         playlist.merge()
 
         assert "name" in playlist.info
-        assert playlist.info["name"] == "service"
+        assert playlist.info["name"] == "internal"
 
     def test_unchanged_service_creates_no_ops(self):
         playlist = SyncedPlaylist("internal")
@@ -288,6 +288,10 @@ class TestMergeInfo:
         playlist.register(first)
         playlist.register(second)
 
+        # Update names
+        first.name = "one"
+        second.name = "two"
+
         playlist.merge()
 
         # Replica 2 merged after replica 1, so its op has the higher counter.
@@ -313,8 +317,9 @@ class TestMergeInfo:
     def test_description_is_merged(self):
         playlist = SyncedPlaylist("internal")
         service = make_playlist(name="service")
-        service.info = PlaylistInfo(name="service", description="service desc")
         playlist.register(service)
+
+        service.info = PlaylistInfo(name="service", description="service desc")
 
         playlist.merge()
 
@@ -337,9 +342,14 @@ class TestMergeInfo:
         """An explicit None description overwrites/clears the internal value."""
         playlist = SyncedPlaylist("internal", description="internal desc")
         service = make_playlist(name="service")
-        service.info = PlaylistInfo(name="service", description=None)
-        playlist.register(service)
+        playlist.register(
+            service  # <- Overwrite the service's info internal info
+        )
 
+        # External change: service's description is cleared
+        service.info = PlaylistInfo(name="service", description=None)
+
+        # Merge should propagate the None value to the internal info.
         playlist.merge()
 
         assert "description" in playlist.info


### PR DESCRIPTION
`SyncedPlaylist` state can now be serialized to and restored from a plain JSON-compatible snapshot, enabling persisted sync state across runs. The CRDT layer (Fugue + LWW register) gains a generic serializer abstraction, and the sync layer builds on it to snapshot the full replicated playlist state.

TODOs:
- [x] ~~Docs~~ Later
- [x] ~~Example~~ Later
- [x] Changelog